### PR TITLE
Several improvements to endpoints listing

### DIFF
--- a/src/api/com.js
+++ b/src/api/com.js
@@ -4,7 +4,21 @@ const baseUrl = 'https://public-api.wordpress.com/rest/';
 const api = {
 	name: 'WP.COM API',
 	getDiscoveryUrl: version => baseUrl + version + '/help',
-	parseEndpoints: data => data,
+	parseEndpoints: data => {
+		const documented = [];
+		const undocumented = [];
+		const noGroup = [];
+		data.forEach( endpoint => {
+			if ( endpoint.group === '__do_not_document' ) {
+				undocumented.push( endpoint );
+			} else if ( endpoint.group ) {
+				documented.push( endpoint );
+			} else {
+				noGroup.push( endpoint );
+			}
+		} );
+		return documented.concat( noGroup ).concat( undocumented );
+	},
 	loadVersions: () =>
 		superagent.get( baseUrl + 'v1.1/versions?include_dev=true' )
 			.set( 'accept', 'application/json' )

--- a/src/api/com.js
+++ b/src/api/com.js
@@ -9,6 +9,10 @@ const api = {
 		const undocumented = [];
 		const noGroup = [];
 		data.forEach( endpoint => {
+			endpoint.pathFormat = endpoint.path_format;
+			delete endpoint.path_format;
+			endpoint.pathLabeled = endpoint.path_labeled;
+			delete endpoint.path_labeled;
 			if ( endpoint.group === '__do_not_document' ) {
 				undocumented.push( endpoint );
 			} else if ( endpoint.group ) {

--- a/src/api/core.js
+++ b/src/api/core.js
@@ -55,7 +55,18 @@ export const guessEndpointDocumentation = ( method, namespace, computedPath ) =>
 				}
 
 				if ( /\/users\/me$/.test( computedPath ) ) {
-					return 'Get the current user';
+					switch ( method ) {
+						case 'GET':
+							return 'Get the current user';
+						case 'POST':
+						case 'PUT':
+						case 'PATCH':
+							return 'Edit the current user';
+						case 'DELETE':
+							return 'Delete the current user';
+						default: // make eslint happy
+							return 'Unknown action with the current user';
+					}
 				}
 
 				if ( /\/revisions(\/|$)/.test( computedPath ) ) {

--- a/src/api/core.js
+++ b/src/api/core.js
@@ -5,6 +5,8 @@ export const guessEndpointDocumentation = ( method, namespace, computedPath ) =>
 	let groupSingular = '';
 	let description = '';
 
+	computedPath = computedPath || '/';
+
 	const verbMatch = computedPath.match( /^(\/?sites\/[$\w.]+)?\/([\w-]*)(\/|$)/ );
 
 	if ( verbMatch ) {

--- a/src/components/endpoint-selector/index.js
+++ b/src/components/endpoint-selector/index.js
@@ -38,10 +38,20 @@ class EndpointSelector extends Component {
 			<li key={ index } onClick={ onSelectEndpoint( endpoint ) }>
 				<span className="method">{ endpoint.method }</span>
 				<code>{ endpoint.pathLabeled }</code>
-				<strong>{ endpoint.group }</strong>
+				<strong>{ this.getGroupText( endpoint.group ) }</strong>
 				<em>{ endpoint.description }</em>
 			</li>
 		);
+	}
+
+	getGroupText( group, isHeading = false ) {
+		if ( group === '__do_not_document' ) {
+			return ( isHeading ? '(Undocumented)' : '' );
+		}
+		if ( ! group ) {
+			return ( isHeading ? '(No group)' : '' );
+		}
+		return group;
 	}
 
 	render() {
@@ -57,7 +67,7 @@ class EndpointSelector extends Component {
 				}
 				{ Object.keys( groupedEndpoints ).map( group =>
 					<div key={ group }>
-						<div className="group">{ group }</div>
+						<div className="group">{ this.getGroupText( group, true ) }</div>
 						<ul>{ this.renderEndpoints( groupedEndpoints[ group ] ) }</ul>
 					</div>
 				)}

--- a/src/components/endpoint-selector/index.js
+++ b/src/components/endpoint-selector/index.js
@@ -51,7 +51,8 @@ class EndpointSelector extends Component {
 		if ( ! group ) {
 			return ( isHeading ? '(No group)' : '' );
 		}
-		return group;
+		// Add a zero-width space to force 'text-transform: capitalize' to work
+		return ( isHeading ? '' : '\u200b' ) + group;
 	}
 
 	render() {

--- a/src/components/endpoint-selector/index.js
+++ b/src/components/endpoint-selector/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { groupBy, noop } from 'lodash';
+import { groupBy, sortBy, noop } from 'lodash';
 
 import './style.css';
 
@@ -34,7 +34,7 @@ class EndpointSelector extends Component {
 		const { onSelect } = this.props;
 		const onSelectEndpoint = endpoint => () => onSelect( endpoint );
 
-		return endpoints.map( ( endpoint, index ) =>
+		return sortBy( endpoints, 'pathLabeled' ).map( ( endpoint, index ) =>
 			<li key={ index } onClick={ onSelectEndpoint( endpoint ) }>
 				<span className="method">{ endpoint.method }</span>
 				<code>{ endpoint.pathLabeled }</code>

--- a/src/components/endpoint-selector/style.css
+++ b/src/components/endpoint-selector/style.css
@@ -32,7 +32,7 @@
 	font-weight: 100;
 }
 
-.endpoint-selector li.highlight {
+.endpoint-selector li:hover {
 	background-color: hsl(205,38%,94%);
 }
 

--- a/src/components/endpoint-selector/style.css
+++ b/src/components/endpoint-selector/style.css
@@ -14,14 +14,11 @@
 }
 
 .endpoint-selector ul {
-	position: relative;
 	opacity: 0.96;
 	list-style: none;
 	padding: 0;
 	margin: 0;
 	background: hsl(210,33%,100%);
-	position: relative;
-	top: 1px;
 }
 
 .endpoint-selector li {
@@ -103,6 +100,7 @@
 	font-weight: bold;
 	border-top: 1px solid hsl(210,33%,100%);
 	background: hsl(210,33%,100%);
+	border-bottom: 1px solid #e6eff4;
 }
 
 .endpoint-selector .group:first-child {

--- a/src/lib/redux/cache.js
+++ b/src/lib/redux/cache.js
@@ -7,7 +7,7 @@ const HOUR_IN_MS = 3600000;
 const SERIALIZE_THROTTLE = 500;
 const MAX_AGE = 30 * DAY_IN_HOURS * HOUR_IN_MS;
 const STORAGE_KEY = 'REDUX_STATE';
-const SERIALIZED_STATE_VERSION = 2;
+const SERIALIZED_STATE_VERSION = 3;
 
 function serialize( state, reducer ) {
 	const serializedState = reducer( state, { type: SERIALIZE } );


### PR DESCRIPTION
While making these changes I noticed that they do not take effect until I do `localStorage.clear()`, because the endpoints and their parsed documentation are stored in the cached redux state.

We should probably not store the documentation in the state, or at least we should refresh the list of endpoints when the application loads, and then update the state with the new list.