### PR TITLE
Fix avatar URL property name from v1 API

### DIFF
--- a/src/auth/basic.js
+++ b/src/auth/basic.js
@@ -16,7 +16,7 @@ const createBasicAuthProvider = ( name, baseUrl, authHeader ) => {
 				const user = res.body.body;
 				return {
 					...user,
-					avatarURL: user.avatar_urls ? Object.values( user.avatar_urls )[ 0 ] : '',
+					avatarUrl: user.avatar_urls ? Object.values( user.avatar_urls )[ 0 ] : '',
 				};
 			} );
 	};

--- a/src/auth/oauth1.js
+++ b/src/auth/oauth1.js
@@ -72,7 +72,7 @@ const createOauth1Provider = ( name, baseUrl, callbackUrl, publicKey, secretKey 
 			const user = body.body;
 			return {
 				...user,
-				avatarURL: user.avatar_urls ? Object.values( user.avatar_urls )[ 0 ] : '',
+				avatarUrl: user.avatar_urls ? Object.values( user.avatar_urls )[ 0 ] : '',
 			};
 		} );
 	};

--- a/src/auth/oauth2.js
+++ b/src/auth/oauth2.js
@@ -39,7 +39,13 @@ const createAuthProvider = ( name, baseUrl, userUrl, redirectUrl, clientId ) => 
 			.get( userUrl )
 			.set( 'accept', 'application/json' )
 			.set( 'Authorization', `BEARER ${ accessToken }` )
-			.then( res => res.body );
+			.then( res => {
+				if ( res.body && res.body.avatar_URL ) {
+					res.body.avatarUrl = res.body.avatar_URL;
+					delete res.body.avatar_URL;
+				}
+				return res.body;
+			} );
 	};
 
 	const logout = () => {

--- a/src/components/user-menu/index.js
+++ b/src/components/user-menu/index.js
@@ -32,7 +32,7 @@ const UserMenu = ( { apiName, isReady, isLoggedin, login, logout, user } ) => {
 			<span className="label" />
 			<span className="extra">Sign Out</span>
 			<span className="img">
-				<img alt="Avatar" src={ user.avatarURL } />
+				<img alt="Avatar" src={ user.avatarUrl } />
 			</span>
 		</div>
 	);


### PR DESCRIPTION
Fixes a bug introduced in a46e524 (the v1 API returns an `avatar_URL` property; since I changed the name for consistency, we need to change it in this API response also).