### PR TITLE
Auth: Specify scope=global for WP.COM REST API

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -18,6 +18,7 @@ if ( wpcomConfig ) {
 		userUrl: 'https://public-api.wordpress.com/rest/v1.1/me',
 		redirectUrl: wpcomConfig.redirectUrl || wpcomConfig.redirect_uri,
 		clientId: wpcomConfig.clientID || wpcomConfig.clientId || wpcomConfig.client_id,
+		scope: 'global',
 	};
 	const authProvider = config[ 'wordpress.com' ].auth === 'proxy'
 		? proxy
@@ -26,7 +27,8 @@ if ( wpcomConfig ) {
 				oauth2Config.baseUrl,
 				oauth2Config.userUrl,
 				oauth2Config.redirectUrl,
-				oauth2Config.clientId
+				oauth2Config.clientId,
+				oauth2Config.scope
 			);
 
 	const hasOrgWebsites = !! config[ 'wordpress.org' ] && !! Object.keys( config[ 'wordpress.org' ] ).length;

--- a/src/auth/oauth2.js
+++ b/src/auth/oauth2.js
@@ -1,7 +1,7 @@
 import superagent from 'superagent';
 import querystring from 'querystring';
 
-const createAuthProvider = ( name, baseUrl, userUrl, redirectUrl, clientId ) => {
+const createAuthProvider = ( name, baseUrl, userUrl, redirectUrl, clientId, scope = null ) => {
 	const TOKEN_STORAGE_KEY = `${ name }__OAUTH2ACCESSTOKEN`;
 	const REQUEST_TOKEN_STORAGE_KEY = `${ name }__REQUESTOAUTH2ACCESSTOKEN`;
 
@@ -26,7 +26,7 @@ const createAuthProvider = ( name, baseUrl, userUrl, redirectUrl, clientId ) => 
 		if ( localStorage.getItem( REQUEST_TOKEN_STORAGE_KEY ) ) {
 			localStorage.removeItem( REQUEST_TOKEN_STORAGE_KEY );
 			localStorage.setItem( TOKEN_STORAGE_KEY, token );
-			window.history.replaceState( {}, null, window.location.pathname );
+			window.location = window.location.pathname;
 		}
 	};
 
@@ -56,8 +56,9 @@ const createAuthProvider = ( name, baseUrl, userUrl, redirectUrl, clientId ) => 
 	const login = () => {
 		localStorage.setItem( REQUEST_TOKEN_STORAGE_KEY, '1' );
 		window.location = `${ baseUrl }/authorize?` +
-			`client_id=${ encodeURIComponent( clientId ) }&response_type=token&` +
-			`redirect_uri=${ redirectUrl }`;
+			`client_id=${ encodeURIComponent( clientId ) }&response_type=token` +
+			( scope ? `&scope=${ scope }` : '' ) +
+			`&redirect_uri=${ redirectUrl }`;
 	};
 
 	const request = ( { method, url, body } ) => {


### PR DESCRIPTION
In theory, this should fix #38 but for some reason it's not working for me :(.

maybe you could have a look @nylen 

