### PR TITLE
JSON display improvements

### DIFF
--- a/src/components/results/index.js
+++ b/src/components/results/index.js
@@ -12,6 +12,10 @@ import { escapeLikeJSON, stringify } from './utils';
 const Results = ( { results } ) => {
 	const jsonTheme = {
 		extend: 'default',
+		tree: {
+			MozUserSelect: 'text',
+			WebkitUserSelect: 'text',
+		},
 		nestedNodeItemString: ( node, expandedNodes, type, expanded ) => {
 			return {
 				className: expanded ? 'expanded' : 'collapsed',

--- a/src/components/results/index.js
+++ b/src/components/results/index.js
@@ -15,7 +15,7 @@ class Results extends React.Component {
 	}
 
 	componentWillUnmount() {
-		document.removeEventListener( 'click', this.overrideClickIfSelected );
+		document.removeEventListener( 'click', this.overrideClickIfSelected, true );
 	}
 
 	overrideClickIfSelected = event => {

--- a/src/components/results/index.js
+++ b/src/components/results/index.js
@@ -7,7 +7,7 @@ import './style.css';
 
 import RequestHeader from './header';
 import { getResults } from '../../state/results/selectors';
-import { stringify } from './utils';
+import { escapeLikeJSON, stringify } from './utils';
 
 const Results = ( { results } ) => {
 	const jsonTheme = {
@@ -20,14 +20,33 @@ const Results = ( { results } ) => {
 	};
 
 	const expandFalse = () => false;
-	const itemString = ( type, data, itemType, itemString ) => (
-		/* eslint-disable */
+	const getItemString = ( type, data, itemType, itemString ) => (
+		/* eslint-disable react/no-danger */
 		<span
 			className="collapsed-content"
 			dangerouslySetInnerHTML={ { __html: `${ itemString } <span class="content">${ stringify( data ) }</span>` } }
 		/>
-		/* eslint-enable */
+		/* eslint-enable react/no-danger */
 	);
+
+	const valueRenderer = value => {
+		if ( typeof value === 'string' ) {
+			const valueWithoutQuotes = value.replace( /^"|"$/g, '' );
+			let valueEscaped;
+			if ( valueWithoutQuotes === value ) {
+				// Probably a boolean or number
+				valueEscaped = escapeLikeJSON( value );
+			} else {
+				// String
+				valueEscaped = '"' + escapeLikeJSON( valueWithoutQuotes ) + '"';
+			}
+			return (
+				<span className="expanded-value">{ valueEscaped }</span>
+			);
+		}
+
+		return value;
+	};
 
 	return (
 		<div className="results">
@@ -40,7 +59,8 @@ const Results = ( { results } ) => {
 								theme={ jsonTheme }
 								data={ result.response.body }
 								shouldExpandNode={ expandFalse }
-								getItemString={ itemString }
+								getItemString={ getItemString }
+								valueRenderer={ valueRenderer }
 							/>
 						</div>
 					}

--- a/src/components/results/index.js
+++ b/src/components/results/index.js
@@ -9,70 +9,88 @@ import RequestHeader from './header';
 import { getResults } from '../../state/results/selectors';
 import { escapeLikeJSON, stringify } from './utils';
 
-const Results = ( { results } ) => {
-	const jsonTheme = {
-		extend: 'default',
-		tree: {
-			MozUserSelect: 'text',
-			WebkitUserSelect: 'text',
-		},
-		nestedNodeItemString: ( node, expandedNodes, type, expanded ) => {
-			return {
-				className: expanded ? 'expanded' : 'collapsed',
-			};
-		},
-	};
+class Results extends React.Component {
+	componentWillMount() {
+		document.addEventListener( 'click', this.overrideClickIfSelected, true );
+	}
 
-	const expandFalse = () => false;
-	const getItemString = ( type, data, itemType, itemString ) => (
-		/* eslint-disable react/no-danger */
-		<span
-			className="collapsed-content"
-			dangerouslySetInnerHTML={ { __html: `${ itemString } <span class="content">${ stringify( data ) }</span>` } }
-		/>
-		/* eslint-enable react/no-danger */
-	);
+	componentWillUnmount() {
+		document.removeEventListener( 'click', this.overrideClickIfSelected );
+	}
 
-	const valueRenderer = value => {
-		if ( typeof value === 'string' ) {
-			const valueWithoutQuotes = value.replace( /^"|"$/g, '' );
-			let valueEscaped;
-			if ( valueWithoutQuotes === value ) {
-				// Probably a boolean or number
-				valueEscaped = escapeLikeJSON( value );
-			} else {
-				// String
-				valueEscaped = '"' + escapeLikeJSON( valueWithoutQuotes ) + '"';
-			}
-			return (
-				<span className="expanded-value">{ valueEscaped }</span>
-			);
+	overrideClickIfSelected = event => {
+		if ( window.getSelection().toString().length ) {
+			event.stopPropagation();
 		}
-
-		return value;
 	};
 
-	return (
-		<div className="results">
-			{ results.map( ( result, index ) =>
-				<div key={ result.id } className={ classnames( 'request', { error: result.response && !! result.response.error } ) }>
-					<RequestHeader result={ result } />
-					{ result.response && result.response.body &&
-						<div className="response">
-							<JSONTree
-								theme={ jsonTheme }
-								data={ result.response.body }
-								shouldExpandNode={ expandFalse }
-								getItemString={ getItemString }
-								valueRenderer={ valueRenderer }
-							/>
-						</div>
-					}
-				</div>
-			)}
-		</div>
-	);
-};
+	render() {
+		const { results } = this.props;
+
+		const jsonTheme = {
+			extend: 'default',
+			tree: {
+				MozUserSelect: 'text',
+				WebkitUserSelect: 'text',
+			},
+			nestedNodeItemString: ( node, expandedNodes, type, expanded ) => {
+				return {
+					className: expanded ? 'expanded' : 'collapsed',
+				};
+			},
+		};
+
+		const expandFalse = () => false;
+		const getItemString = ( type, data, itemType, itemString ) => (
+			/* eslint-disable react/no-danger */
+			<span
+				className="collapsed-content"
+				dangerouslySetInnerHTML={ { __html: `${ itemString } <span class="content">${ stringify( data ) }</span>` } }
+			/>
+			/* eslint-enable react/no-danger */
+		);
+
+		const valueRenderer = value => {
+			if ( typeof value === 'string' ) {
+				const valueWithoutQuotes = value.replace( /^"|"$/g, '' );
+				let valueEscaped;
+				if ( valueWithoutQuotes === value ) {
+					// Probably a boolean or number
+					valueEscaped = escapeLikeJSON( value );
+				} else {
+					// String
+					valueEscaped = '"' + escapeLikeJSON( valueWithoutQuotes ) + '"';
+				}
+				return (
+					<span className="expanded-value">{ valueEscaped }</span>
+				);
+			}
+
+			return value;
+		};
+
+		return (
+			<div className="results">
+				{ results.map( ( result, index ) =>
+					<div key={ result.id } className={ classnames( 'request', { error: result.response && !! result.response.error } ) }>
+						<RequestHeader result={ result } />
+						{ result.response && result.response.body &&
+							<div className="response">
+								<JSONTree
+									theme={ jsonTheme }
+									data={ result.response.body }
+									shouldExpandNode={ expandFalse }
+									getItemString={ getItemString }
+									valueRenderer={ valueRenderer }
+								/>
+							</div>
+						}
+					</div>
+				)}
+			</div>
+		);
+	}
+}
 
 export default connect(
 	state => {

--- a/src/components/results/style.css
+++ b/src/components/results/style.css
@@ -54,6 +54,11 @@
 	color: rgb(92, 129, 21);
 }
 
+.collapsed-content .string,
+.expanded-value {
+	white-space: pre-wrap;
+}
+
 .collapsed-content .number {
 	color: rgb(246, 103, 30);
 }

--- a/src/components/results/tests/utils.test.js
+++ b/src/components/results/tests/utils.test.js
@@ -33,6 +33,14 @@ it( 'should crop the output if we exceed max', () => {
 	expect( stringify( object, 5 ) ).toEqual( expected );
 } );
 
+it( 'should not display an ellipsis if all keys are rendered', () => {
+	const object = {
+		a23456: 'b23456',
+	};
+	const expected = '{ <span class="key">a23456</span>: <span class="string">"b23456"</span> }';
+	expect( stringify( object, 5 ) ).toEqual( expected );
+} );
+
 it( 'should encode HTML-like characters in keys and values', () => {
 	const object = {
 		'<': 'some stuff & more stuff',

--- a/src/components/results/tests/utils.test.js
+++ b/src/components/results/tests/utils.test.js
@@ -7,7 +7,7 @@ it( 'should stringify an object recursively', () => {
 			d: 'e',
 		},
 	};
-	const expected = '{<span class="key">"a"</span>:<span class="string">"b"</span>, <span class="key">"c"</span>:{<span class="key">"d"</span>:<span class="string">"e"</span>}}';  // eslint-disable-line max-len
+	const expected = '{ <span class="key">a</span>: <span class="string">"b"</span>, <span class="key">c</span>: { <span class="key">d</span>: <span class="string">"e"</span> } }';  // eslint-disable-line max-len
 	expect( stringify( object ) ).toEqual( expected );
 } );
 
@@ -18,17 +18,17 @@ it( 'should stringify an array recursively', () => {
 		'b',
 		[ 'c', 'd' ],
 	];
-	const expected = '[<span class="key">"0"</span>:<span class="string">"a"</span>, <span class="key">"1"</span>:<span class="string">"b"</span>, <span class="key">"2"</span>:[<span class="key">"0"</span>:<span class="string">"c"</span>, <span class="key">"1"</span>:<span class="string">"d"</span>]]';  // eslint-disable-line max-len
+	const expected = '[ <span class="key">0</span>: <span class="string">"a"</span>, <span class="key">1</span>: <span class="string">"b"</span>, <span class="key">2</span>: [ <span class="key">0</span>: <span class="string">"c"</span>, <span class="key">1</span>: <span class="string">"d"</span> ] ]';  // eslint-disable-line max-len
 	expect( stringify( object ) ).toEqual( expected );
 } );
 
 it( 'should crop the output if we exceed max', () => {
 	const object = {
-		a: 'b',
-		c: {
-			d: 'e',
+		a23456: 'b23456',
+		c23456: {
+			d23456: 'e23456',
 		},
 	};
-	const expected = '{<span class="key">"a"</span>:<span class="string">"b"</span> …}';
+	const expected = '{ <span class="key">a23456</span>: <span class="string">"b23456"</span> …}';
 	expect( stringify( object, 5 ) ).toEqual( expected );
 } );

--- a/src/components/results/tests/utils.test.js
+++ b/src/components/results/tests/utils.test.js
@@ -32,3 +32,17 @@ it( 'should crop the output if we exceed max', () => {
 	const expected = '{ <span class="key">a23456</span>: <span class="string">"b23456"</span> …}';
 	expect( stringify( object, 5 ) ).toEqual( expected );
 } );
+
+it( 'should encode HTML-like characters in keys and values', () => {
+	const object = {
+		'<': 'some stuff & more stuff',
+		'>': '<_< >_>',
+		'&': 'another "<test>"',
+	};
+	const expected = '{ ' +
+		'<span class="key">&lt;</span>: <span class="string">"some stuff &amp; more stuff"</span>, ' +
+		'<span class="key">&gt;</span>: <span class="string">"&lt;_&lt; &gt;_&gt;"</span>, ' +
+		'<span class="key">&amp;</span>: <span class="string">"another \\"&lt;test&gt;\\""</span> ' +
+		'}';
+	expect( stringify( object, 999 ) ).toEqual( expected );
+} );

--- a/src/components/results/tests/utils.test.js
+++ b/src/components/results/tests/utils.test.js
@@ -46,3 +46,13 @@ it( 'should encode HTML-like characters in keys and values', () => {
 		'}';
 	expect( stringify( object, 999 ) ).toEqual( expected );
 } );
+
+it( 'should encode whitespace characters in keys and values', () => {
+	const object = {
+		'a\tb\r\nc"d"e\n\\f': 'a\tb\r\nc"d"e\n\\f',
+	};
+	const expected = '{ ' +
+		'<span class="key">a\\tb\\r\\nc\\"d\\"e\\n\\\\f</span>: <span class="string">"a\\tb\\r\\nc\\"d\\"e\\n\\\\f"</span> ' +
+		'}';
+	expect( stringify( object, 999 ) ).toEqual( expected );
+} );

--- a/src/components/results/utils.js
+++ b/src/components/results/utils.js
@@ -2,6 +2,16 @@ import { isArray, isPlainObject, isString, toPairs, toString } from 'lodash';
 
 const MAX_LENGTH = 60;
 
+const escapeHTML = html => {
+	const replacements = {
+		'&': '&amp;',
+		'<': '&lt;',
+		'>': '&gt;',
+	};
+
+	return html.replace( /[&<>]/g, ch => replacements[ ch ] );
+};
+
 const recursiveStringify = ( data, max = MAX_LENGTH ) => {
 	if ( isPlainObject( data ) || isArray( data ) ) {
 		const pairs = toPairs( data );
@@ -10,7 +20,7 @@ const recursiveStringify = ( data, max = MAX_LENGTH ) => {
 		let trailing = '';
 		let length = 2;
 		for ( const [ key, value ] of pairs ) {
-			const keyString = key.toString();
+			const keyString = escapeHTML( key.toString() );
 			output += trailing;
 			output += '<span class="key">' + keyString + '</span>: ';
 			const recursion = recursiveStringify( value );
@@ -32,9 +42,10 @@ const recursiveStringify = ( data, max = MAX_LENGTH ) => {
 	}
 
 	if ( isString( data ) ) {
+		const displayValue = escapeHTML( data ).replace( /"/g, '\\"' );
 		return {
 			length: data.length + 2,
-			output: '<span class="string">"' + data.replace( /"/g, '\\"' ) + '"</span>',
+			output: '<span class="string">"' + displayValue + '"</span>',
 		};
 	}
 

--- a/src/components/results/utils.js
+++ b/src/components/results/utils.js
@@ -34,6 +34,7 @@ const recursiveStringify = ( data, max = MAX_LENGTH ) => {
 		let output = isArray( data ) ? '[ ' : '{ ';
 		let trailing = '';
 		let length = 2;
+		let keysRendered = 0;
 		for ( const [ key, value ] of pairs ) {
 			const keyString = escapeLikeJSON( escapeHTML( key.toString() ) );
 			output += trailing;
@@ -41,8 +42,9 @@ const recursiveStringify = ( data, max = MAX_LENGTH ) => {
 			const recursion = recursiveStringify( value );
 			output += recursion.output;
 			length += keyString.length + trailing.length + recursion.length;
+			keysRendered++;
 			trailing = ', ';
-			if ( length > max ) {
+			if ( length > max && keysRendered < pairs.length ) {
 				output += isArray( data ) ? ' …]' : ' …}';
 				return {
 					length: length + 3,

--- a/src/components/results/utils.js
+++ b/src/components/results/utils.js
@@ -2,7 +2,7 @@ import { isArray, isPlainObject, isString, toPairs, toString } from 'lodash';
 
 const MAX_LENGTH = 60;
 
-const escapeHTML = html => {
+export const escapeHTML = html => {
 	const replacements = {
 		'&': '&amp;',
 		'<': '&lt;',
@@ -12,7 +12,7 @@ const escapeHTML = html => {
 	return html.replace( /[&<>]/g, ch => replacements[ ch ] );
 };
 
-const escapeLikeJSON = value => {
+export const escapeLikeJSON = value => {
 	const replacements = {
 		'\r': '\\r',
 		'\n': '\\n',

--- a/src/components/results/utils.js
+++ b/src/components/results/utils.js
@@ -6,15 +6,16 @@ const recursiveStringify = ( data, max = MAX_LENGTH ) => {
 	if ( isPlainObject( data ) || isArray( data ) ) {
 		const pairs = toPairs( data );
 
-		let output = isArray( data ) ? '[' : '{';
+		let output = isArray( data ) ? '[ ' : '{ ';
 		let trailing = '';
-		let length = 1;
+		let length = 2;
 		for ( const [ key, value ] of pairs ) {
+			const keyString = key.toString();
 			output += trailing;
-			output += '<span class="key">"' + key + '"</span>:';
+			output += '<span class="key">' + keyString + '</span>: ';
 			const recursion = recursiveStringify( value );
 			output += recursion.output;
-			length += key.toString().length + 2 + trailing.length + recursion.length;
+			length += keyString.length + trailing.length + recursion.length;
 			trailing = ', ';
 			if ( length > max ) {
 				output += isArray( data ) ? ' …]' : ' …}';
@@ -25,8 +26,8 @@ const recursiveStringify = ( data, max = MAX_LENGTH ) => {
 			}
 		}
 		return {
-			output: output + ( isArray( data ) ? ']' : '}' ),
-			length: length + 1,
+			output: output + ( isArray( data ) ? ' ]' : ' }' ),
+			length: length + 2,
 		};
 	}
 

--- a/src/components/results/utils.js
+++ b/src/components/results/utils.js
@@ -12,6 +12,21 @@ const escapeHTML = html => {
 	return html.replace( /[&<>]/g, ch => replacements[ ch ] );
 };
 
+const escapeLikeJSON = value => {
+	const replacements = {
+		'\r': '\\r',
+		'\n': '\\n',
+		'\t': '\\t',
+		'"': '\\"',
+	};
+
+	return value
+		// Replace backslashes first to avoid doubling them in other places.
+		.replace( /\\/g, '\\\\' )
+		// Then replace everything else (multiple spaces are handled via CSS).
+		.replace( /\r|\n|\t|"/g, ch => replacements[ ch ] );
+};
+
 const recursiveStringify = ( data, max = MAX_LENGTH ) => {
 	if ( isPlainObject( data ) || isArray( data ) ) {
 		const pairs = toPairs( data );
@@ -20,7 +35,7 @@ const recursiveStringify = ( data, max = MAX_LENGTH ) => {
 		let trailing = '';
 		let length = 2;
 		for ( const [ key, value ] of pairs ) {
-			const keyString = escapeHTML( key.toString() );
+			const keyString = escapeLikeJSON( escapeHTML( key.toString() ) );
 			output += trailing;
 			output += '<span class="key">' + keyString + '</span>: ';
 			const recursion = recursiveStringify( value );
@@ -42,7 +57,7 @@ const recursiveStringify = ( data, max = MAX_LENGTH ) => {
 	}
 
 	if ( isString( data ) ) {
-		const displayValue = escapeHTML( data ).replace( /"/g, '\\"' );
+		const displayValue = escapeLikeJSON( escapeHTML( data ) );
 		return {
 			length: data.length + 2,
 			output: '<span class="string">"' + displayValue + '"</span>',


### PR DESCRIPTION
Trying to make JSON easier to read using spaces, removing quotes around string keys, etc.

#### Before
![image](https://cloud.githubusercontent.com/assets/227022/20297433/2b3ce8d2-aad6-11e6-95bf-645867b674da.png)
#### After
![image](https://cloud.githubusercontent.com/assets/227022/20297436/303126c8-aad6-11e6-93a1-9d0c3161bd52.png)

We should consider whitespace handling as well.  Currently any combination of whitespace inside a key or value (including newlines, tabs, or multiple spaces) will be condensed down to a single space.