### PR TITLE
Fix/timestamp state bug

### DIFF
--- a/src/lib/redux/cache.js
+++ b/src/lib/redux/cache.js
@@ -10,7 +10,7 @@ const STORAGE_KEY = 'REDUX_STATE';
 
 function serialize( state, reducer ) {
 	const serializedState = reducer( state, { type: SERIALIZE } );
-	return Object.assign( serializedState, {
+	return Object.assign( {}, serializedState, {
 		_timestamp: Date.now(),
 	} );
 }

--- a/src/lib/redux/cache.js
+++ b/src/lib/redux/cache.js
@@ -8,7 +8,7 @@ const SERIALIZE_THROTTLE = 500;
 const MAX_AGE = 30 * DAY_IN_HOURS * HOUR_IN_MS;
 const STORAGE_KEY = 'REDUX_STATE';
 
-function serialize( state, reducer ) {
+export function serialize( state, reducer ) {
 	const serializedState = reducer( state, { type: SERIALIZE } );
 	return Object.assign( {}, serializedState, {
 		_timestamp: Date.now(),

--- a/src/lib/redux/tests/cache.test.js
+++ b/src/lib/redux/tests/cache.test.js
@@ -1,0 +1,15 @@
+import { serialize } from '../cache';
+
+describe( 'serialize', () => {
+	it( 'should not modify the original object', () => {
+		// Otherwise we get this error sometimes:
+		// Unexpected keys "_timestamp", "_version" found in previous state
+		const state = {};
+		const dummyReducer = state => state;
+
+		const serialized = serialize( state, dummyReducer );
+		expect( serialized._timestamp ).toBeGreaterThan( 0 );
+
+		expect( state._timestamp ).toBeUndefined();
+	} );
+} );


### PR DESCRIPTION
Fixes #48.

I am not sure of the exact sequence of calls that causes the bug, but it is related to `serialize` modifying the object that it is passed.