### PR TITLE
Errors: Better error messages

### DIFF
--- a/src/auth/basic.js
+++ b/src/auth/basic.js
@@ -42,10 +42,10 @@ const createBasicAuthProvider = ( name, baseUrl, authHeader ) => {
 		return new Promise( resolve =>
 			req.end( ( err, response = {} ) => {
 				let error = err;
-				if ( err && response.body && response.body.error ) {
+				if ( err && response.body && response.body.code ) {
+					error = response.body.code;
+				} else if ( err && response.body && response.body.error ) {
 					error = response.body.error;
-				} else if ( err && response.error ) {
-					error = response.error.message;
 				}
 
 				resolve( {

--- a/src/auth/basic.js
+++ b/src/auth/basic.js
@@ -41,17 +41,10 @@ const createBasicAuthProvider = ( name, baseUrl, authHeader ) => {
 
 		return new Promise( resolve =>
 			req.end( ( err, response = {} ) => {
-				let error = err;
-				if ( err && response.body && response.body.code ) {
-					error = response.body.code;
-				} else if ( err && response.body && response.body.error ) {
-					error = response.body.error;
-				}
-
 				resolve( {
 					status: response.status,
 					body: response.body,
-					error,
+					error: err,
 				} );
 			} )
 		);

--- a/src/auth/oauth1.js
+++ b/src/auth/oauth1.js
@@ -112,10 +112,10 @@ const createOauth1Provider = ( name, baseUrl, callbackUrl, publicKey, secretKey 
 
 			req.end( ( err, response = {} ) => {
 				let error = err;
-				if ( err && response.body && response.body.error ) {
+				if ( err && response.body && response.body.code ) {
+					error = response.body.code;
+				} else if ( err && response.body && response.body.error ) {
 					error = response.body.error;
-				} else if ( err && response.error ) {
-					error = response.error.message;
 				}
 
 				resolve( {

--- a/src/auth/oauth1.js
+++ b/src/auth/oauth1.js
@@ -111,17 +111,10 @@ const createOauth1Provider = ( name, baseUrl, callbackUrl, publicKey, secretKey 
 			}
 
 			req.end( ( err, response = {} ) => {
-				let error = err;
-				if ( err && response.body && response.body.code ) {
-					error = response.body.code;
-				} else if ( err && response.body && response.body.error ) {
-					error = response.body.error;
-				}
-
 				resolve( {
 					status: response.status,
 					body: response.body,
-					error,
+					error: err,
 				} );
 			} );
 		} );

--- a/src/auth/oauth2.js
+++ b/src/auth/oauth2.js
@@ -76,10 +76,10 @@ const createAuthProvider = ( name, baseUrl, userUrl, redirectUrl, clientId, scop
 		return new Promise( resolve =>
 			req.end( ( err, response = {} ) => {
 				let error = err;
-				if ( err && response.body && response.body.error ) {
+				if ( err && response.body && response.body.code ) {
+					error = response.body.code;
+				} else if ( err && response.body && response.body.error ) {
 					error = response.body.error;
-				} else if ( err && response.error ) {
-					error = response.error.message;
 				}
 
 				resolve( {

--- a/src/auth/oauth2.js
+++ b/src/auth/oauth2.js
@@ -75,17 +75,10 @@ const createAuthProvider = ( name, baseUrl, userUrl, redirectUrl, clientId, scop
 
 		return new Promise( resolve =>
 			req.end( ( err, response = {} ) => {
-				let error = err;
-				if ( err && response.body && response.body.code ) {
-					error = response.body.code;
-				} else if ( err && response.body && response.body.error ) {
-					error = response.body.error;
-				}
-
 				resolve( {
 					status: response.status,
 					body: response.body,
-					error,
+					error: err,
 				} );
 			} )
 		);

--- a/src/auth/proxy.js
+++ b/src/auth/proxy.js
@@ -28,7 +28,9 @@ export const request = req =>
 	new Promise( resolve => {
 		proxy( req, ( err, body, xhr ) => {
 			let error = err;
-			if ( err && body && body.error ) {
+			if ( err && body && body.code ) {
+				error = body.code;
+			} else if ( err && body && body.error ) {
 				error = body.error;
 			}
 

--- a/src/auth/proxy.js
+++ b/src/auth/proxy.js
@@ -27,17 +27,10 @@ export const boot = () =>
 export const request = req =>
 	new Promise( resolve => {
 		proxy( req, ( err, body, xhr ) => {
-			let error = err;
-			if ( err && body && body.code ) {
-				error = body.code;
-			} else if ( err && body && body.error ) {
-				error = body.error;
-			}
-
 			resolve( {
 				status: xhr.status,
 				body,
-				error,
+				error: err,
 			} );
 		} );
 	} )

--- a/src/components/results/header/index.js
+++ b/src/components/results/header/index.js
@@ -14,9 +14,16 @@ const RequestHeader = ( { result: { loading, request: { path, method, apiName, v
 			<code className="apiName">{ apiName }</code>
 			<code className="method">{ method }</code>
 			<code className="path">{ `${ version }${ path }` }</code>
-			{ response && !! response.error && <span className="error">{ `${ response.status } - ${ response.error }` }</span> }
-			{ duration && <span className="duration">{ `${ duration }ms` }</span> }
-			{ response && !! duration.body &&
+			{ response && !! response.error && (
+				<span className="error">
+					{ response.status && `${ response.status } - ` }
+					{ response.error }
+				</span>
+			) }
+			{ duration && (
+				<span className="duration">{ `${ duration }ms` }</span>
+			) }
+			{ response && !! duration.body && (
 				<a
 					className="download"
 					title="Download"
@@ -25,8 +32,10 @@ const RequestHeader = ( { result: { loading, request: { path, method, apiName, v
 					rel="noreferrer noopener"
 					href={ 'data:application/json;charset=UTF-8,' + encodeURIComponent( JSON.stringify( response.body, null, '\t' ) ) }
 				/>
-			}
-			{ loading && <div className="throbber"><div /></div> }
+			) }
+			{ loading && (
+				<div className="throbber"><div /></div>
+			) }
 		</div>
 	);
 };

--- a/src/components/results/header/index.js
+++ b/src/components/results/header/index.js
@@ -23,7 +23,7 @@ const RequestHeader = ( { result: { loading, request: { path, method, apiName, v
 			{ duration && (
 				<span className="duration">{ `${ duration }ms` }</span>
 			) }
-			{ response && !! duration.body && (
+			{ response && !! response.body && (
 				<a
 					className="download"
 					title="Download"

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,0 +1,48 @@
+const isEnvelopedResponse = ( status, body, error ) => {
+	if ( status !== 200 ) {
+		return false;
+	}
+
+	if ( body && body.code && body.headers && 'body' in body ) {
+		// Enveloped response from v1 API (?http_envelope=true)
+		return true;
+	}
+
+	if ( body && body.status && body.headers && 'body' in body ) {
+		// Enveloped response from v2 API (?_envelope)
+		return true;
+	}
+
+	return false;
+};
+
+export const getResponseStatus = ( status, body, error ) => {
+	if ( isEnvelopedResponse( status, body, error ) ) {
+		return body.status || body.code || status;
+	}
+
+	return status;
+};
+
+export const getResponseError = ( rawStatus, rawBody, error, log = false ) => {
+	const status = getResponseStatus( rawStatus, rawBody, error );
+	if ( status >= 200 && status <= 299 && ! error ) {
+		return null;
+	}
+
+	let body = rawBody;
+	if ( isEnvelopedResponse( rawStatus, rawBody, error ) ) {
+		body = rawBody.body;
+	}
+
+	if ( body && body.code ) {
+		return body.code;
+	} else if ( body && body.error ) {
+		return body.error;
+	} else {
+		if ( error && log ) {
+			console.log( 'Full error message:', error.message || error );
+		}
+		return 'Unknown error (check browser console)';
+	}
+};

--- a/src/lib/tests/api.test.js
+++ b/src/lib/tests/api.test.js
@@ -1,0 +1,79 @@
+import { getResponseStatus, getResponseError } from '../api';
+
+describe( 'getResponseStatus', () => {
+	it( 'should return the plain status code', () => {
+		expect( getResponseStatus( 200, null, null ) ).toEqual( 200 );
+		expect( getResponseStatus( 404, null, null ) ).toEqual( 404 );
+	} );
+
+	it( 'should return the enveloped status code (v1 API)', () => {
+		const status = getResponseStatus( 200, {
+			code: 404,
+			headers: [],
+			body: '',
+		}, null );
+		expect( status ).toEqual( 404 );
+	} );
+
+	it( 'should return the enveloped status code (v2 API)', () => {
+		const status = getResponseStatus( 200, {
+			status: 404,
+			headers: [],
+			body: '',
+		}, null );
+		expect( status ).toEqual( 404 );
+	} );
+} );
+
+describe( 'getResponseError', () => {
+	it( 'should return null if no error', () => {
+		expect( getResponseError( 200, null, null ) ).toEqual( null );
+		expect( getResponseError( 201, null, null ) ).toEqual( null );
+	} );
+
+	it( 'should process a plain error from the v1 API', () => {
+		const error = getResponseError( 404, {
+			error: 'something_bad',
+		}, new Error() );
+		expect( error ).toEqual( 'something_bad' );
+	} );
+
+	it( 'should process a plain error from the v2 API', () => {
+		const error = getResponseError( 404, {
+			code: 'something_bad',
+		}, new Error() );
+		expect( error ).toEqual( 'something_bad' );
+	} );
+
+	it( 'should return an unknown error if not 200', () => {
+		const error = getResponseError( 404, null, null );
+		expect( error ).toMatch( /^Unknown error/ );
+	} );
+
+	it( 'should return an unknown error if no body or status', () => {
+		const error = getResponseError( null, null, new Error() );
+		expect( error ).toMatch( /^Unknown error/ );
+	} );
+
+	it( 'should process an enveloped error from the v1 API', () => {
+		const error = getResponseError( 200, {
+			code: 404,
+			headers: [],
+			body: {
+				error: 'something_bad',
+			},
+		}, null );
+		expect( error ).toEqual( 'something_bad' );
+	} );
+
+	it( 'should process an enveloped error from the v2 API', () => {
+		const error = getResponseError( 200, {
+			status: 404,
+			headers: [],
+			body: {
+				code: 'something_bad',
+			},
+		}, null );
+		expect( error ).toEqual( 'something_bad' );
+	} );
+} );

--- a/src/state/results/actions.js
+++ b/src/state/results/actions.js
@@ -2,6 +2,7 @@ import { REQUEST_RESULTS_RECEIVE, REQUEST_TRIGGER } from '../actions';
 import { getRequestMethod, getCompleteQueryUrl, getBodyParams } from '../request/selectors';
 import { getSelectedApi, getSelectedVersion } from '../ui/selectors';
 import { get } from '../../api';
+import { getResponseStatus, getResponseError } from '../../lib/api';
 
 window.responses = [];
 const recordResponse = response => {
@@ -70,12 +71,6 @@ export const request = () => ( dispatch, getState ) => {
 
 	return api.authProvider.request( request )
 		.then( ( { status, body, error } ) => {
-			if ( error && body && body.code ) {
-				error = body.code;
-			} else if ( error && body && body.error ) {
-				error = body.error;
-			}
-
 			const end = new Date().getTime();
 			dispatch( receiveResults( {
 				id: start,
@@ -83,9 +78,9 @@ export const request = () => ( dispatch, getState ) => {
 				apiName,
 				method,
 				path,
-				status,
+				status: getResponseStatus( status, body, error ),
 				body,
-				error,
+				error: getResponseError( status, body, error, true ),
 				duration: end - start,
 			} ) );
 		} );

--- a/src/state/results/actions.js
+++ b/src/state/results/actions.js
@@ -13,7 +13,7 @@ const recordResponse = response => {
 		'%c window.response ready with ' +
 			Object.keys( response ).length +
 			' keys. Previous responses in window.responses[].'
-		, 'color: #cccccc;'
+		, 'color: #777;'
 	);
 };
 

--- a/src/state/results/actions.js
+++ b/src/state/results/actions.js
@@ -45,6 +45,12 @@ export const request = () => ( dispatch, getState ) => {
 
 	return api.authProvider.request( request )
 		.then( ( { status, body, error } ) => {
+			if ( error && body && body.code ) {
+				error = body.code;
+			} else if ( error && body && body.error ) {
+				error = body.error;
+			}
+
 			const end = new Date().getTime();
 			dispatch( receiveResults( start, version, apiName, method, path, status, body, error, end - start ) );
 		} );

--- a/src/state/results/actions.js
+++ b/src/state/results/actions.js
@@ -16,15 +16,34 @@ const recordResponse = response => {
 	);
 };
 
-const receiveResults = ( id, version, apiName, method, path, status, body, error, duration ) => {
-	recordResponse( { version, apiName, method, path, status, body, error, duration } );
+const receiveResults = ( {
+	id,
+	version,
+	apiName,
+	method,
+	path,
+	status,
+	body,
+	error,
+	duration,
+} ) => {
+	recordResponse( {
+		version,
+		apiName,
+		method,
+		path,
+		status,
+		body,
+		error,
+		duration,
+	} );
 	return {
 		type: REQUEST_RESULTS_RECEIVE,
 		payload: { id, status, body, error, duration },
 	};
 };
 
-const triggerRequest = ( id, version, apiName, method, path ) => {
+const triggerRequest = ( { id, version, apiName, method, path } ) => {
 	return {
 		type: REQUEST_TRIGGER,
 		payload: { id, version, apiName, method, path },
@@ -41,7 +60,13 @@ export const request = () => ( dispatch, getState ) => {
 	const body = getBodyParams( state );
 	const start = new Date().getTime();
 	const request = api.buildRequest( version, method, path, body );
-	dispatch( triggerRequest( start, version, apiName, method, path ) );
+	dispatch( triggerRequest( {
+		id: start,
+		version,
+		apiName,
+		method,
+		path,
+	} ) );
 
 	return api.authProvider.request( request )
 		.then( ( { status, body, error } ) => {
@@ -52,6 +77,16 @@ export const request = () => ( dispatch, getState ) => {
 			}
 
 			const end = new Date().getTime();
-			dispatch( receiveResults( start, version, apiName, method, path, status, body, error, end - start ) );
+			dispatch( receiveResults( {
+				id: start,
+				version,
+				apiName,
+				method,
+				path,
+				status,
+				body,
+				error,
+				duration: end - start,
+			} ) );
 		} );
 };


### PR DESCRIPTION
If the response body contains a "code" attribute, use that for the error or use the "error" attribute instead.

This should resolve #26 However I was not able to reproduce the first use case of the ticket. 

cc @nylen 
