### PR TITLE
Fix Query String construction when using oauth1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "is-my-json-valid": "^2.15.0",
     "lodash": "^4.16.4",
     "oauth-1.0a": "^2.0.0",
-    "querystring": "^0.2.0",
+    "qs": "^6.3.0",
     "react": "^15.3.2",
     "react-click-outside": "github:tj/react-click-outside",
     "react-dom": "^15.3.2",

--- a/src/auth/oauth2.js
+++ b/src/auth/oauth2.js
@@ -1,5 +1,5 @@
 import superagent from 'superagent';
-import querystring from 'querystring';
+import qs from 'qs';
 
 const createAuthProvider = ( name, baseUrl, userUrl, redirectUrl, clientId, scope = null ) => {
 	const TOKEN_STORAGE_KEY = `${ name }__OAUTH2ACCESSTOKEN`;
@@ -19,7 +19,7 @@ const createAuthProvider = ( name, baseUrl, userUrl, redirectUrl, clientId, scop
 			return;
 		}
 		const hash = url.slice( index + 1 );
-		const queryParams = querystring.parse( hash );
+		const queryParams = qs.parse( hash );
 		const token = queryParams.access_token;
 
 		// This ensures we're requesting the current access token (not another oauth2 provider)

--- a/src/state/request/selectors.js
+++ b/src/state/request/selectors.js
@@ -80,8 +80,7 @@ export const getCompleteQueryUrl = state => {
 	const queryParams = getQueryParams( state );
 	const buildParamUrl = ( param, value ) => {
 		if ( isArray( value ) ) {
-			// If we dont specify the index, oauth1 will fail
-			return value.map( ( subvalue, index ) => `${ param }[${ index }]=${ encodeURIComponent( subvalue ) }` )
+			return value.map( subvalue => `${ param }[]=${ encodeURIComponent( subvalue ) }` )
 				.join( '&' );
 		}
 

--- a/src/state/request/selectors.js
+++ b/src/state/request/selectors.js
@@ -80,11 +80,12 @@ export const getCompleteQueryUrl = state => {
 	const queryParams = getQueryParams( state );
 	const buildParamUrl = ( param, value ) => {
 		if ( isArray( value ) ) {
-			return value.map( subvalue => `${ param }[]=${ subvalue }` )
+			// If we dont specify the index, oauth1 will fail
+			return value.map( ( subvalue, index ) => `${ param }[${ index }]=${ encodeURIComponent( subvalue ) }` )
 				.join( '&' );
 		}
 
-		return `${ param }=${ value }`;
+		return `${ param }=${ encodeURIComponent( value ) }`;
 	};
 	const queryString = Object.keys( queryParams ).length === 0
 		? ''


### PR DESCRIPTION
When we use OAuth1 as the oauth provider, the array parameters on the URL should have indexes and of course, we should URL encode all the parameters.

This will help the API testing :)

@nylen 