### PR TITLE
Parameters of type "object" use JSON.parse/stringify to show/update their values

### DIFF
--- a/src/components/param-builder/index.js
+++ b/src/components/param-builder/index.js
@@ -1,17 +1,15 @@
 import React from 'react';
 import { isUndefined } from 'lodash';
-import TagsInput from 'react-tagsinput';
-import 'react-tagsinput/react-tagsinput.css';
 
 import './style.css';
 
 import CloseButton from '../close-button';
 import ParamTooltip from '../param-tooltip';
+import ParamInput from './input';
 
 const ParamBuilder = ( { title, params, values = {}, onChange } ) => {
 	const hasParams = !! params && Object.keys( params ).length > 0;
 	const changeParamValue = paramKey => value => onChange( paramKey, value );
-	const changeParamEventValue = paramKey => event => onChange( paramKey, event.target.value );
 	const resetParamValues = paramKey => () => onChange( paramKey );
 
 	return (
@@ -26,23 +24,12 @@ const ParamBuilder = ( { title, params, values = {}, onChange } ) => {
 								<tr key={ paramKey }>
 									<th>{ paramKey }</th>
 									<td>
-										{
-											parameter.type === 'array'
-												? <TagsInput
-													value={ values[ paramKey ] || [] }
-													inputProps={ {
-														placeholder: 'Add a value',
-														'data-tip': true,
-														'data-for': `param-${ paramKey }`,
-													} }
-													onChange={ changeParamValue( paramKey ) }
-												/>
-												: <input
-													type="text" value={ values[ paramKey ] || '' }
-													data-tip data-for={ `param-${ paramKey }` }
-													onChange={ changeParamEventValue( paramKey ) }
-												/>
-										}
+										<ParamInput
+											onChange={ changeParamValue( paramKey ) }
+											type={ parameter.type }
+											value={ values[ paramKey ] }
+											data-tip data-for={ `param-${ paramKey }` }
+										/>
 										{ ! isUndefined( values[ paramKey ] ) &&
 											<CloseButton onClick={ resetParamValues( paramKey ) } />
 										}

--- a/src/components/param-builder/input.jsx
+++ b/src/components/param-builder/input.jsx
@@ -1,0 +1,53 @@
+import React, { PropTypes } from 'react';
+import { isString } from 'lodash';
+import TagsInput from 'react-tagsinput';
+import 'react-tagsinput/react-tagsinput.css';
+
+const ParamInput = ( { onChange, type, value, ...props } ) => {
+	switch ( type ) {
+		case 'array':
+			return (
+				<TagsInput
+					value={ value || [] }
+					inputProps={ {
+						placeholder: 'Add a value',
+						...props,
+					} }
+					onChange={ onChange }
+				/>
+			);
+		case 'object':
+			const stringifiedValue = isString( value ) ? value : JSON.stringify( value );
+			const onChangeObject = event => {
+				const eventValue = event.target.value;
+				const parsedValue = eventValue.length && eventValue[ 0 ] === '{'
+					? JSON.parse( eventValue )
+					: eventValue;
+				onChange( parsedValue );
+			};
+			return (
+				<input
+					type="text" value={ stringifiedValue || '' }
+					onChange={ onChangeObject }
+					{ ...props }
+				/>
+			);
+		default:
+			const onChangeEvent = event => onChange( event.target.value );
+			return (
+				<input
+					type="text" value={ value || '' }
+					onChange={ onChangeEvent }
+					{ ...props }
+				/>
+			);
+	}
+};
+
+ParamInput.propTypes = {
+	onChange: PropTypes.func.isRequired,
+	type: PropTypes.string,
+	value: PropTypes.any,
+};
+
+export default ParamInput;


### PR DESCRIPTION
While working on this, I noticed a small issue for title, content and some other fields. The API accepts either a raw string value, but it also accepts an object like this `{"raw":"awesome title"}`. So the type of the field is "object" while we use this as "string" most of the time.

I'm curious to hear your opinion on this. How should we handle this?

 - Should we hard code these fields in discovery as "string" (seems difficult to ensure maintenance for this) or should we keep this way (since the "{" detection avoids the JSON parsing to trigger)

closes #57 

cc @nylen 