### PR TITLE
Fix the user avatar when we're using the proxy authentication

### DIFF
--- a/src/auth/proxy.js
+++ b/src/auth/proxy.js
@@ -18,6 +18,10 @@ export const boot = () =>
 					reject();
 					return;
 				}
+				if ( response.avatar_URL ) {
+					response.avatarUrl = response.avatar_URL;
+					delete response.avatar_URL;
+				}
 				resolve( response );
 			} );
 		} );


### PR DESCRIPTION
The attribute name has been changed in the other authentication methods, in this PR I match the avatar attribute name for the proxy authentication