### PR TITLE
Fix version 1.2 and higher endpoints

### DIFF
--- a/src/api/com.js
+++ b/src/api/com.js
@@ -2,53 +2,49 @@ import superagent from 'superagent';
 
 const baseUrl = 'https://public-api.wordpress.com/rest/';
 
-export const api = {
-	name: 'WP.COM API',
-	getDiscoveryUrl: version => baseUrl + version + '/help',
-	parseEndpoints: data => {
-		const documented = [];
-		const undocumented = [];
-		const noGroup = [];
-		data.forEach( endpoint => {
-			endpoint.pathFormat = endpoint.path_format;
-			delete endpoint.path_format;
-			endpoint.pathLabeled = endpoint.path_labeled;
-			delete endpoint.path_labeled;
-			if ( endpoint.group === '__do_not_document' ) {
-				undocumented.push( endpoint );
-			} else if ( endpoint.group ) {
-				documented.push( endpoint );
-			} else {
-				noGroup.push( endpoint );
-			}
-		} );
-		return documented.concat( noGroup ).concat( undocumented );
-	},
-	loadVersions: () =>
-		superagent.get( baseUrl + 'v1.1/versions?include_dev=true' )
-			.set( 'accept', 'application/json' )
-			.then( res => {
-				return {
-					versions: res.body.versions.map( version => `v${ version }` ),
-					current: `v${ res.body.current_version }`,
-				};
-			} ),
-	buildRequest: ( version, method, path, body ) => {
-		return {
-			url: baseUrl + version + path,
-			apiVersion: version.substr( 1 ),
-			method,
-			path,
-			body,
-		};
-	},
-	baseUrl,
-};
-
 const createApi = authProvider => {
 	return {
 		authProvider,
-		...api,
+		name: 'WP.COM API',
+		getDiscoveryUrl: version => baseUrl + version + '/help',
+		parseEndpoints: data => {
+			const documented = [];
+			const undocumented = [];
+			const noGroup = [];
+			data.forEach( endpoint => {
+				endpoint.pathFormat = endpoint.path_format;
+				delete endpoint.path_format;
+				endpoint.pathLabeled = endpoint.path_labeled;
+				delete endpoint.path_labeled;
+				if ( endpoint.group === '__do_not_document' ) {
+					undocumented.push( endpoint );
+				} else if ( endpoint.group ) {
+					documented.push( endpoint );
+				} else {
+					noGroup.push( endpoint );
+				}
+			} );
+			return documented.concat( noGroup ).concat( undocumented );
+		},
+		loadVersions: () =>
+			superagent.get( baseUrl + 'v1.1/versions?include_dev=true' )
+				.set( 'accept', 'application/json' )
+				.then( res => {
+					return {
+						versions: res.body.versions.map( version => `v${ version }` ),
+						current: `v${ res.body.current_version }`,
+					};
+				} ),
+		buildRequest: ( version, method, path, body ) => {
+			return {
+				url: baseUrl + version + path,
+				apiVersion: version.substr( 1 ),
+				method,
+				path,
+				body,
+			};
+		},
+		baseUrl,
 	};
 };
 

--- a/src/api/com.js
+++ b/src/api/com.js
@@ -1,5 +1,3 @@
-import superagent from 'superagent';
-
 const baseUrl = 'https://public-api.wordpress.com/rest/';
 
 const createApi = authProvider => {
@@ -27,14 +25,15 @@ const createApi = authProvider => {
 			return documented.concat( noGroup ).concat( undocumented );
 		},
 		loadVersions: () =>
-			superagent.get( baseUrl + 'v1.1/versions?include_dev=true' )
-				.set( 'accept', 'application/json' )
-				.then( res => {
-					return {
-						versions: res.body.versions.map( version => `v${ version }` ),
-						current: `v${ res.body.current_version }`,
-					};
-				} ),
+			authProvider.request( {
+				method: 'GET',
+				url: baseUrl + 'v1.1/versions?include_dev=true',
+			} ).then( res => {
+				return {
+					versions: res.body.versions.map( version => `v${ version }` ),
+					current: `v${ res.body.current_version }`,
+				};
+			} ),
 		buildRequest: ( version, method, path, body ) => {
 			return {
 				url: baseUrl + version + path,

--- a/src/api/tests/com.test.js
+++ b/src/api/tests/com.test.js
@@ -1,6 +1,8 @@
 import { clone } from 'lodash';
 
-import { api } from '../com';
+import createApi from '../com';
+
+const api = createApi( { request: () => {} } );
 
 function getEndpointTestData() {
 	/* eslint-disable camelcase */


### PR DESCRIPTION
We need to make an authenticated request to the `v1.1/versions` endpoint, otherwise it just returns versions 1 and 1.1.