### PR TITLE
Fix the query box input's style on safari

### DIFF
--- a/src/components/param-builder/style.css
+++ b/src/components/param-builder/style.css
@@ -47,6 +47,7 @@
 }
 
 .param-builder td input {
+	margin: 0;
 	padding: 8px;
 	font-size: 16px;
 	max-width: 100%;


### PR DESCRIPTION
Closes #69 
