### PR TITLE
Move the user login/logout menu to the right

### DIFF
--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -12,10 +12,10 @@ const Header = () =>
 	(
 		<div id="header">
 			<ApiSelector />
-			<UserMenu />
 			<VersionSelector />
 			<LookupContainer />
 			<Submit />
+			<UserMenu />
 		</div>
 	)
 ;

--- a/src/components/submit/style.css
+++ b/src/components/submit/style.css
@@ -3,18 +3,18 @@
 	min-width: 44px;
 	text-align: center;
 	box-sizing: border-box;
-	background: url(res/return-@2x.png) no-repeat center center hsl(202,68%,44%);
+	background: url(res/return-dark-@2x.png) no-repeat center center hsl(201,60%,100%);
 	background-size: 24px 24px;
 	color: hsl(201,60%,97%);
 }
 
 #submit:hover, #submit:focus {
 	outline: none;
+	background-image: url(res/return-@2x.png);
 	background-color: hsl(201,60%,70%);
 }
 
 #submit:active, #submit.active {
+	background-image: url(res/return-@2x.png);
 	color: hsl(201,60%,70%);
-	background-color: hsl(201,60%,100%);
-	background-image: url(res/return-dark-@2x.png);
 }

--- a/src/components/user-menu/style.css
+++ b/src/components/user-menu/style.css
@@ -24,8 +24,7 @@
 	background-color: hsl(201,60%,100%);
 }
 
-.user-menu:hover, .user-menu:focus {
-	outline: none;
+.user-menu:hover {
 	background-color: hsl(201,60%,70%);
 	color: #FFF;
 }
@@ -55,10 +54,6 @@
 	display: block;
 	width: 44px;
 	height: 44px;
-	opacity: 0;
-	transition: opacity 200ms 200ms;
-	-webkit-transition: opacity 200ms 200ms;
-	-moz-transition: opacity 200ms 200ms;
 }
 
 .user-menu.authorized .label::before {
@@ -78,8 +73,7 @@
 	cursor: default;
 }
 
-.user-menu.loading:hover, .user-menu.loading:focus {
-	outline: none;
+.user-menu:hover {
 	background-color: hsl(201,60%,60%);
 }
 
@@ -87,23 +81,12 @@
 	display: inline-block;
 	width: 0;
 	overflow: hidden;
-	transition: 200ms 100ms;
-	opacity: 0;
 	white-space: nowrap;
-}
-
-.user-menu:hover .extra, .user-menu:focus .extra {
-	opacity: 1;
 	width: 64px;
 }
 
-.user-menu.authorized:hover .extra, .user-menu.authorized:focus .extra {
-	opacity: 1;
+.user-menu.authorized .extra {
 	width: 110px;
-}
-
-.user-menu:hover img, .user-menu:focus img {
-	opacity: 0.9;
 }
 
 .uesr-menu .throbber {

--- a/src/components/user-menu/style.css
+++ b/src/components/user-menu/style.css
@@ -68,7 +68,6 @@
 }
 
 .user-menu.loading {
-	min-width: 40px;
 	justify-content: center;
 	cursor: default;
 }


### PR DESCRIPTION
closes #65 

Also, make the Sign In/Out text always visible

<img width="1153" alt="screen shot 2017-02-24 at 10 03 09" src="https://cloud.githubusercontent.com/assets/272444/23297136/9672567c-fa78-11e6-870f-a22837df644a.png">
