### PR TITLE
Authentication: Clear invalid tokens when authentication boot request fails

### DIFF
--- a/src/api/com.js
+++ b/src/api/com.js
@@ -24,16 +24,22 @@ const createApi = authProvider => {
 			} );
 			return documented.concat( noGroup ).concat( undocumented );
 		},
-		loadVersions: () =>
-			authProvider.request( {
-				method: 'GET',
-				url: baseUrl + 'v1.1/versions?include_dev=true',
-			} ).then( res => {
-				return {
-					versions: res.body.versions.map( version => `v${ version }` ),
-					current: `v${ res.body.current_version }`,
-				};
-			} ),
+		loadVersions: () => {
+			const loadVersions = () =>
+				authProvider.request( {
+					method: 'GET',
+					url: baseUrl + 'v1.1/versions?include_dev=true',
+				} ).then( res => {
+					return {
+						versions: res.body.versions.map( version => `v${ version }` ),
+						current: `v${ res.body.current_version }`,
+					};
+				} );
+
+			return authProvider.boot()
+				.then( loadVersions )
+				.catch( loadVersions );
+		},
 		buildRequest: ( version, method, path, body ) => {
 			return {
 				url: baseUrl + version + path,

--- a/src/auth/oauth1.js
+++ b/src/auth/oauth1.js
@@ -73,7 +73,7 @@ const createOauth1Provider = ( name, baseUrl, callbackUrl, publicKey, secretKey 
 				...user,
 				avatarUrl: user.avatar_urls ? Object.values( user.avatar_urls )[ 0 ] : '',
 			};
-		}, () => {
+		}, err => {
 			accessToken = null;
 			localStorage.removeItem( TOKEN_STORAGE_KEY );
 			return Promise.reject();

--- a/src/auth/oauth1.js
+++ b/src/auth/oauth1.js
@@ -73,6 +73,10 @@ const createOauth1Provider = ( name, baseUrl, callbackUrl, publicKey, secretKey 
 				...user,
 				avatarUrl: user.avatar_urls ? Object.values( user.avatar_urls )[ 0 ] : '',
 			};
+		}, () => {
+			accessToken = null;
+			localStorage.removeItem( TOKEN_STORAGE_KEY );
+			return Promise.reject();
 		} );
 	};
 

--- a/src/auth/oauth2.js
+++ b/src/auth/oauth2.js
@@ -5,8 +5,7 @@ const createAuthProvider = ( name, baseUrl, userUrl, redirectUrl, clientId, scop
 	const TOKEN_STORAGE_KEY = `${ name }__OAUTH2ACCESSTOKEN`;
 	const REQUEST_TOKEN_STORAGE_KEY = `${ name }__REQUESTOAUTH2ACCESSTOKEN`;
 
-	let accessToken = false;
-
+	let accessToken = null;
 	const init = () => {
 		// Extract any token from url or localstorage
 		accessToken = localStorage.getItem( TOKEN_STORAGE_KEY );
@@ -46,8 +45,8 @@ const createAuthProvider = ( name, baseUrl, userUrl, redirectUrl, clientId, scop
 				}
 				return res.body;
 			}, err => {
+				accessToken = null;
 				localStorage.removeItem( TOKEN_STORAGE_KEY );
-				accessToken = false;
 				return Promise.reject();
 			} );
 	};

--- a/src/auth/oauth2.js
+++ b/src/auth/oauth2.js
@@ -45,6 +45,10 @@ const createAuthProvider = ( name, baseUrl, userUrl, redirectUrl, clientId, scop
 					delete res.body.avatar_URL;
 				}
 				return res.body;
+			}, err => {
+				localStorage.removeItem( TOKEN_STORAGE_KEY );
+				accessToken = false;
+				return Promise.reject();
 			} );
 	};
 


### PR DESCRIPTION
closes #73 

OAuth tokens were never cleaned. In this PR, if the authentication boot request fails, I clean the token from local storage.