### PR TITLE
Allow using the console with cookie authentication

### DIFF
--- a/src/api/core-autodiscover.js
+++ b/src/api/core-autodiscover.js
@@ -1,0 +1,32 @@
+import { parseEndpoints } from './core';
+
+const createApi = ( authProvider, name, url, namespaces = [ 'wp/v2' ] ) => {
+	return {
+		getDiscoveryUrl: version => `${ url }${ version }?context=help`,
+		loadVersions: () => new Promise( resolve => authProvider.request( {
+			method: 'GET',
+			url,
+		} ).then( ( res, err ) => {
+			if ( err ) {
+				return resolve( { versions: namespaces } );
+			}
+			const ns = res.body.namespaces;
+			return resolve( { versions: ns } );
+		} ) ),
+		buildRequest: ( version, method, path, body ) => {
+			return {
+				url: url + version + path,
+				apiNamespace: version,
+				method,
+				path,
+				body,
+			};
+		},
+		baseUrl: url,
+		authProvider,
+		name,
+		parseEndpoints,
+	};
+};
+
+export default createApi;

--- a/src/auth/local.js
+++ b/src/auth/local.js
@@ -1,0 +1,60 @@
+import superagent from 'superagent';
+
+const createLocalAuthProvider = settings => {
+	const { baseUrl, nonce, loggedInUserId } = settings;
+	const boot = () => {
+		if ( ! nonce ) {
+			return Promise.reject();
+		}
+
+		const userUrl = `${ baseUrl }wp/v2/users/${ loggedInUserId }`;
+
+		return superagent
+			.get( userUrl )
+			.set( 'accept', 'application/json' )
+			.set( 'X-WP-Nonce', nonce )
+			.then( res => {
+				const user = res.body.body;
+				return {
+					...user,
+					avatarUrl: '',
+				};
+			} );
+	};
+
+	const login = () => {
+		if ( ! nonce ) {
+			return Promise.reject( 'nonce not set' );
+		}
+
+		return Promise.resolve();
+	};
+
+	const request = ( { method, url, body } ) => {
+		const req = superagent( method, url )
+			.set( 'accept', 'application/json' )
+			.set( 'X-WP-Nonce', nonce );
+
+		if ( body && Object.keys( body ).length > 0 ) {
+			req.send( body );
+		}
+
+		return new Promise( resolve =>
+			req.end( ( err, response = {} ) => {
+				resolve( {
+					status: response.status,
+					body: response.body,
+					error: err,
+				} );
+			} )
+		);
+	};
+
+	const logout = () => {};
+
+	return {
+		boot, login, logout, request,
+	};
+};
+
+export default createLocalAuthProvider;

--- a/src/config.local_dev.json
+++ b/src/config.local_dev.json
@@ -1,0 +1,10 @@
+{
+	"wordpress.org": [
+		{
+			"name": "localDev",
+			"authType": "local_dev",
+			"globalObjectName": "wpApiSettings",
+			"url": "http://no-need-for-url.com"
+		}
+	]
+}


### PR DESCRIPTION
This is useful for local REST API development or for embedding the console as a plugin into an existing wordpress installation.

* introduces a new auth provider 
* introduces a new api creator (core with autodiscovery)

It requires a predefined JavaScript global object is
available on the page.

The name of that global is defined in config.json under globalObjectName

example config:

```json
{
  "wordpress.org": [
    {
      "name": "localDev",
      "authType": "local_dev",
      "globalObjectName": "wpApiSettings",
      "url": "http://no-need-for-url.com"
    }
  ]
}
```

The JS object can be obtained like this (in this case the
`globalObjectName` in the config should be named `wpApiSettings`)

```php
wp_localize_script( 'wp-api', 'wpApiSettings', array(
  'nonce' => wp_create_nonce( 'wp_rest' ),
  'url' => esc_url_raw( site_url() ),
  'baseUrl' => esc_url_raw( trailingslashit( rest_url() ) ),
  'loggedInUserId' => get_current_user_id()
) );
```