### PR TITLE
Authentication: Fix versions fetching in proxy auth and move the default wpcom config to use proxy

### DIFF
--- a/src/api/com.js
+++ b/src/api/com.js
@@ -29,6 +29,8 @@ const createApi = authProvider => {
 				authProvider.request( {
 					method: 'GET',
 					url: baseUrl + 'v1.1/versions?include_dev=true',
+					path: '/versions',
+					apiVersion: '1.1',
 				} ).then( res => {
 					return {
 						versions: res.body.versions.map( version => `v${ version }` ),

--- a/src/auth/proxy.js
+++ b/src/auth/proxy.js
@@ -32,7 +32,7 @@ export const request = req =>
 	new Promise( resolve => {
 		proxy( req, ( err, body, xhr ) => {
 			resolve( {
-				status: xhr.status,
+				status: xhr.status === undefined ? 200 : xhr.status,
 				body,
 				error: err,
 			} );

--- a/src/config.wpcom.json
+++ b/src/config.wpcom.json
@@ -1,6 +1,5 @@
 {
 	"wordpress.com": {
-		"clientID": "51972",
-		"redirectUrl": "https://developer.wordpress.com/docs/api/console/"
+		"auth": "proxy"
 	}
 }


### PR DESCRIPTION
Also a small fix in handling responses for the WP REST API. Successful requests were shown as errors.