### PR TITLE
Bumping wpcom-proxy-request to ^4.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "redux": "^3.6.0",
     "redux-thunk": "^2.1.0",
     "superagent": "^2.3.0",
-    "wpcom-proxy-request": "^3.1.0"
+    "wpcom-proxy-request": "^4.0.6"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
The console is using an older version of `wpcom-proxy-request` [3.1.0](https://github.com/Automattic/wpcom-proxy-request/blob/3.1.0/index.js).

It it causing an error to appear when testing  `wpcom/v2` API endpoints with addition query strings, requiring that we append `?envelope=1` to the url in order for them to work:

<img width="564" alt="screen shot 2018-01-19 at 12 34 20 pm" src="https://user-images.githubusercontent.com/6458278/35130534-71cb25e2-fd15-11e7-9840-6a680398aab3.png">


<img width="704" alt="screen shot 2018-01-19 at 12 35 00 pm" src="https://user-images.githubusercontent.com/6458278/35130540-789ada84-fd15-11e7-9add-5625aeaec1e6.png">

## More info

See p2: `p3hLNG-127-p2`
