### PR TITLE
Adds wpcom/v3 and wpcom/v4 to WP REST API version selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To setup the environment on your local system with WordPress.com APIs:
 
 1. Clone the repository `git clone https://github.com/Automattic/wp-api-console.git`.
 
-2. Install dependencies `npm install`.
+2. Install dependencies `npm install` (`npm install --legacy-peer-deps` if using node v16 or greater).
 
 3. Open [WordPress.com Developer Resources](https://developer.wordpress.com/apps/)
 

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -35,7 +35,7 @@ if ( wpcomConfig ) {
 	const dotComWPApi = {
 		name: hasOrgWebsites ? 'WP.COM WP REST API' : 'WP REST API',
 		baseUrl: 'https://public-api.wordpress.com/',
-		namespaces: [ 'wp/v2', 'wpcom/v2' ],
+		namespaces: [ 'wp/v2', 'wpcom/v2', 'wpcom/v3', 'wpcom/v4' ],
 	};
 
 	APIs = APIs.concat( [


### PR DESCRIPTION
Adds the `wpcom/v3` and `wpcom/v4` namespaces.

<img width="258" alt="image" src="https://user-images.githubusercontent.com/1699996/133894285-e63a7da5-3424-4821-8640-5c73c8b80a7c.png">

### Testing instructions

- Follow [the instructions for setting up the project locally](https://github.com/Automattic/wp-api-console#getting-started-locally)
- Note that I had to use `npm install --legacy-peer-deps` when using node v16
- Also, I had to remove the `"auth": "proxy"` line from the sample wpcom config, and just use the regular oauth flow to log in
- Test that you can select the `wpcom/v3` namespace from the dropdown and make a test request to `/sites/{site}/gutenberg`
