### PR TITLE
Build: Transpile dependencies that otherwise break the build

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -18,6 +18,12 @@ if ( ! babelLoader ) {
 	throw new Error( 'Couldn\'t find the babel loader config.' );
 }
 
+console.log( 'Adding transpilable dependencies to babel include path' );
+babelLoader.include = [
+	babelLoader.include,
+	/node_modules\/jsonpointer/,
+];
+
 babelLoader.query.plugins = ( babelLoader.query.plugins || [] )
 	.filter( pluginName => pluginName !== 'lodash' )
 	.concat( 'lodash' );


### PR DESCRIPTION
At some point the `jsonpointer` library started shipping code with
ES2015+ syntax and `const` was breaking `UglifyJS`. This has resulted
in an inability to build the project as described in the documention.

In this patch we're adding that module to our list of sources for
`babel` to transpile, removing that syntax which `UglifyJS` doesn't
understand.

cc: @youknowriad 