### PR TITLE
Replace crypto with hash.js to avoid needing Node polyfills

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1578,9 +1578,9 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30001320",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001320.tgz",
-      "integrity": "sha512-k8IP22eSycsYwJdGR7+Yngga7pg7NWE1iQ3PnSJkNkahUkZI6FUOAHSKS6Ewqi5BrketJZSi7PjVph7SUgxcNg==",
+      "version": "1.0.30001325",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001325.tgz",
+      "integrity": "sha512-bqFgqeJcZCMhqBGhfnX97E3LXeg61rEMt0iyTp7DS8BKTOpw9bmesk9wgQCOEA5w0xiKOSd1SkV+N4oL07TnJw==",
       "dev": true
     },
     "cardinal": {
@@ -2073,11 +2073,6 @@
         "boom": "0.4.x"
       }
     },
-    "crypto": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-0.0.3.tgz",
-      "integrity": "sha1-RwqBuGvkxe4XrMggeh9TFa4g27A="
-    },
     "crypto-browserify": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.3.0.tgz",
@@ -2140,9 +2135,9 @@
       }
     },
     "css-what": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.0.1.tgz",
-      "integrity": "sha512-z93ZGFLNc6yaoXAmVhqoSIb+BduplteCt1fepvwhBUQK6MNE4g6fgjpuZKJKp0esUe+vXWlIkwZZjNWoOKw0ZA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
       "dev": true
     },
     "cssesc": {
@@ -2482,9 +2477,9 @@
       "dev": true
     },
     "domelementtype": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
       "dev": true
     },
     "domhandler": {
@@ -2553,9 +2548,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.96",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.96.tgz",
-      "integrity": "sha512-DPNjvNGPabv6FcyjzLAN4C0psN/GgD9rSGvMTuv81SeXG/EX3mCz0wiw9N1tUEnfQXYCJi3H8M0oFPRziZh7rw==",
+      "version": "1.4.106",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.106.tgz",
+      "integrity": "sha512-ZYfpVLULm67K7CaaGP7DmjyeMY4naxsbTy+syVVxT6QHI1Ww8XbJjmr9fDckrhq44WzCrcC5kH3zGpdusxwwqg==",
       "dev": true
     },
     "emojis-list": {
@@ -2685,9 +2680,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.59",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.59.tgz",
-      "integrity": "sha512-cOgyhW0tIJyQY1Kfw6Kr0viu9ZlUctVchRMZ7R0HiH3dxTSp5zJDLecwxUqPUrGKMsgBI1wd1FL+d9Jxfi4cLw==",
+      "version": "0.10.60",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.60.tgz",
+      "integrity": "sha512-jpKNXIt60htYG59/9FGf2PYT3pwMpnEbNKysU+k/4FGwyGtMotOvcZOuW+EmXXYASRqYSXQfGL5cVIthOTgbkg==",
       "dev": true,
       "requires": {
         "es6-iterator": "^2.0.3",
@@ -4652,9 +4647,9 @@
       "dev": true
     },
     "graceful-fs": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true
     },
     "graceful-readlink": {
@@ -4830,6 +4825,15 @@
             "is-buffer": "^1.1.5"
           }
         }
+      }
+    },
+    "hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
       }
     },
     "hawk": {
@@ -5379,9 +5383,9 @@
       }
     },
     "is-number-object": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
-      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
       "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
@@ -5450,10 +5454,13 @@
       "dev": true
     },
     "is-shared-array-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
     },
     "is-stream": {
       "version": "1.1.0",
@@ -6520,6 +6527,11 @@
       "requires": {
         "mime-db": "1.52.0"
       }
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimatch": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "babel-runtime": "^6.11.6",
     "classnames": "^2.2.5",
-    "crypto": "0.0.3",
     "hash.js": "^1.1.7",
     "is-my-json-valid": "^2.15.0",
     "oauth-1.0a": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "babel-runtime": "^6.11.6",
     "classnames": "^2.2.5",
     "crypto": "0.0.3",
+    "hash.js": "^1.1.7",
     "is-my-json-valid": "^2.15.0",
     "oauth-1.0a": "^2.0.0",
     "qs": "^6.3.0",

--- a/src/auth/oauth1.js
+++ b/src/auth/oauth1.js
@@ -1,7 +1,7 @@
 import superagent from 'superagent';
 import qs from 'qs';
 import OAuth from 'oauth-1.0a';
-import crypto from 'crypto';
+import createHmac from 'hash.js/lib/hash/hmac';
 
 const createOauth1Provider = ( name, baseUrl, callbackUrl, publicKey, secretKey ) => {
 	const TOKEN_STORAGE_KEY = `${ name }__OAUTH1CCESSTOKEN`;
@@ -15,7 +15,7 @@ const createOauth1Provider = ( name, baseUrl, callbackUrl, publicKey, secretKey 
 		},
 		signature_method: 'HMAC-SHA1',
 		hash_function( baseString, key ) {
-			return crypto.createHmac( 'sha1', key )
+			return createHmac( 'sha1', key )
 				.update( baseString ).digest( 'base64' );
 		},
 	} );


### PR DESCRIPTION
~**Do not merge until after #89 is merged**~

Previously `babel` included Node polyfills to ensure that libraries relying on them in the browser context would work.

However, this stopped happening in newer versions which means if we want to update `babel` we need to either manually add those polyfills or rely on packages that don't require them.

In this patch we're replacing our use of `crypto` with `hash.js` to remove one of those dependencies.

In the work exploring this change I also considered `createHmac` as a dependency but the overall impact on build size was smalled with `hash.js` and a selective import (which allows only including the HMAC function we use).