### PR TITLE
Remove lodash as a project dependency 

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -24,12 +24,6 @@ babelLoader.include = [
 	/node_modules\/jsonpointer/,
 ];
 
-babelLoader.query.plugins = ( babelLoader.query.plugins || [] )
-	.filter( pluginName => pluginName !== 'lodash' )
-	.concat( 'lodash' );
-
-console.log( 'Added lodash babel plugin to build' );
-
 if ( process.env.WPCOM_BUILD ) {
 	babelLoader.query.plugins.push( path.resolve(
 		__dirname, '..', 'src', 'lib', 'babel-replace-config-import.js'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "homepage": ".",
   "devDependencies": {
     "babel-eslint": "^7.1.0",
-    "babel-plugin-lodash": "^3.2.9",
     "deep-freeze": "0.0.1",
     "eslint": "^3.9.1",
     "eslint-plugin-react": "^6.6.0",
@@ -18,7 +17,6 @@
     "classnames": "^2.2.5",
     "crypto": "0.0.3",
     "is-my-json-valid": "^2.15.0",
-    "lodash": "^4.16.4",
     "oauth-1.0a": "^2.0.0",
     "qs": "^6.3.0",
     "react": "^15.3.2",

--- a/src/api/tests/com.test.js
+++ b/src/api/tests/com.test.js
@@ -1,8 +1,8 @@
-import { clone } from 'lodash';
-
 import createApi from '../com';
 
 const api = createApi( { request: () => {} } );
+
+const clone = data => JSON.parse( JSON.stringify( data ) );
 
 function getEndpointTestData() {
 	/* eslint-disable camelcase */

--- a/src/components/endpoint-selector/index.js
+++ b/src/components/endpoint-selector/index.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { groupBy, sortBy, noop } from 'lodash';
 
 import './style.css';
 
@@ -9,6 +8,29 @@ import { getEndpoints } from '../../state/endpoints/selectors';
 import { getRecentEndpoints } from '../../state/history/selectors';
 import { filterEndpoints } from '../../state/request/selectors';
 import { loadEndpoints } from '../../state/endpoints/actions';
+
+const groupBy = ( collection, property ) => {
+	const groups = {};
+
+	collection.forEach( item => {
+		const group = item[ property ];
+
+		if ( ! groups[ group ] ) {
+			groups[ group ] = [];
+		}
+
+		groups[ group ].push( item );
+	} );
+
+	return groups;
+};
+
+const noop = () => {};
+
+const sortBy = ( collection, property ) =>
+	( collection || [] )
+		.slice()
+		.sort( ( a, b ) => a[ property ] < b[ property ] );
 
 class EndpointSelector extends Component {
 	static defaultProps = {

--- a/src/components/lookup-container/index.js
+++ b/src/components/lookup-container/index.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
 import ClickOutside from 'react-click-outside';
 
 import './style.css';
@@ -61,7 +60,7 @@ class LookupContainer extends Component {
 
 	renderEndpointPath() {
 		const { pathParts, endpoint } = this.props;
-		const getParamValue = param => get( this.props.pathValues, [ param ], '' );
+		const getParamValue = param => ( this.props.pathValues || {} )[ param ] || '';
 		const pathParameterKeys = pathParts.filter( part => part[ 0 ] === '$' );
 		const countInputs = pathParameterKeys.length;
 		const updateUrlPart = part => event => this.props.updatePathValue( part, event.target.value );

--- a/src/components/param-builder/index.js
+++ b/src/components/param-builder/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { isUndefined } from 'lodash';
 
 import './style.css';
 
@@ -30,7 +29,7 @@ const ParamBuilder = ( { title, params, values = {}, onChange } ) => {
 											value={ values[ paramKey ] }
 											data-tip data-for={ `param-${ paramKey }` }
 										/>
-										{ ! isUndefined( values[ paramKey ] ) &&
+										{ undefined !== values[ paramKey ] &&
 											<CloseButton onClick={ resetParamValues( paramKey ) } />
 										}
 										<ParamTooltip

--- a/src/components/param-builder/input.jsx
+++ b/src/components/param-builder/input.jsx
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import { isString } from 'lodash';
 import TagsInput from 'react-tagsinput';
 import 'react-tagsinput/react-tagsinput.css';
 
@@ -17,7 +16,7 @@ const ParamInput = ( { onChange, type, value, ...props } ) => {
 				/>
 			);
 		case 'object':
-			const stringifiedValue = isString( value ) ? value : JSON.stringify( value );
+			const stringifiedValue = 'string' === typeof value ? value : JSON.stringify( value );
 			const onChangeObject = event => {
 				const eventValue = event.target.value;
 				const parsedValue = eventValue.length && eventValue[ 0 ] === '{'

--- a/src/components/param-tooltip/index.js
+++ b/src/components/param-tooltip/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactTooltip from 'react-tooltip';
-import { isPlainObject } from 'lodash';
+import { isPlainObject } from '../../lib/utils';
 
 import './style.css';
 

--- a/src/components/results/utils.js
+++ b/src/components/results/utils.js
@@ -1,4 +1,4 @@
-import { isArray, isPlainObject, isString, toPairs, toString } from 'lodash';
+import { isPlainObject } from '../../lib/utils';
 
 const MAX_LENGTH = 60;
 
@@ -27,11 +27,19 @@ export const escapeLikeJSON = value => {
 		.replace( /\r|\n|\t|"/g, ch => replacements[ ch ] );
 };
 
+const toPairs = data => {
+	if ( ! data ) {
+		return [];
+	}
+
+	return Object.keys( data ).map( key => [ key, data[ key ] ] );
+};
+
 const recursiveStringify = ( data, max = MAX_LENGTH ) => {
-	if ( isPlainObject( data ) || isArray( data ) ) {
+	if ( isPlainObject( data ) || Array.isArray( data ) ) {
 		const pairs = toPairs( data );
 
-		let output = isArray( data ) ? '[ ' : '{ ';
+		let output = Array.isArray( data ) ? '[ ' : '{ ';
 		let trailing = '';
 		let length = 2;
 		let keysRendered = 0;
@@ -45,7 +53,7 @@ const recursiveStringify = ( data, max = MAX_LENGTH ) => {
 			keysRendered++;
 			trailing = ', ';
 			if ( length > max && keysRendered < pairs.length ) {
-				output += isArray( data ) ? ' …]' : ' …}';
+				output += Array.isArray( data ) ? ' …]' : ' …}';
 				return {
 					length: length + 3,
 					output,
@@ -53,12 +61,12 @@ const recursiveStringify = ( data, max = MAX_LENGTH ) => {
 			}
 		}
 		return {
-			output: output + ( isArray( data ) ? ' ]' : ' }' ),
+			output: output + ( Array.isArray( data ) ? ' ]' : ' }' ),
 			length: length + 2,
 		};
 	}
 
-	if ( isString( data ) ) {
+	if ( 'string' === typeof data ) {
 		const displayValue = escapeLikeJSON( escapeHTML( data ) );
 		return {
 			length: data.length + 2,
@@ -67,7 +75,7 @@ const recursiveStringify = ( data, max = MAX_LENGTH ) => {
 	}
 
 	return {
-		length: toString( data ).length,
+		length: data.toString().length,
 		output: '<span class="' + ( typeof data ) + '">' + data + '</span>',
 	};
 };

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,0 +1,24 @@
+const objectCtorString = Function.prototype.toString.call( Object );
+
+export function isPlainObject( value ) {
+	if (
+		value === null ||
+		value === undefined ||
+		typeof value !== 'object' ||
+		value.toString() !== '[object Object]'
+	) {
+		return false;
+	}
+
+	const proto = Object.getPrototypeOf( Object( value ) );
+	if ( proto === null ) {
+		return true;
+	}
+
+	const Ctor = Object.hasOwnProperty.call( proto, 'constructor' ) && proto.constructor;
+	return (
+        typeof Ctor === 'function' &&
+        Ctor instanceof Ctor &&
+		Function.prototype.toString.call( Ctor ) === objectCtorString
+	);
+}

--- a/src/state/endpoints/selectors.js
+++ b/src/state/endpoints/selectors.js
@@ -1,5 +1,9 @@
-import { get } from 'lodash';
+export const getEndpoints = ( state, apiName, version ) => {
+	const endpoints = state.endpoints[ apiName ];
 
-export const getEndpoints = ( state, apiName, version ) =>
-	get( state.endpoints, [ apiName, version ], [] )
-;
+	if ( ! endpoints ) {
+		return [];
+	}
+
+	return endpoints[ version ] || [];
+};

--- a/src/state/history/reducer.js
+++ b/src/state/history/reducer.js
@@ -12,9 +12,9 @@ const reducer = createReducer( {}, {
 		let currentEndpoints = [];
 
 		if ( state[ apiName ] && state[ apiName ][ version ] ) {
-			currentEndpoints = state[ apiName ][ version ].filter(
+			currentEndpoints = state[ apiName ][ version ]?.filter(
 				existingEndpoint => existingEndpoint.pathLabeled !== endpoint.pathLabeled
-			);
+			) || [];
 		}
 
 		return {

--- a/src/state/history/reducer.js
+++ b/src/state/history/reducer.js
@@ -1,7 +1,6 @@
 import { createReducer } from '../../lib/redux/create-reducer';
 import { REQUEST_SELECT_ENDPOINT } from '../actions';
 import schema from './schema';
-import filter from 'lodash/filter';
 
 const MAX_HISTORY_ENDPOINTS = 10;
 
@@ -13,8 +12,8 @@ const reducer = createReducer( {}, {
 		let currentEndpoints = [];
 
 		if ( state[ apiName ] && state[ apiName ][ version ] ) {
-			currentEndpoints = filter( state[ apiName ][ version ], existingEndpoint =>
-				existingEndpoint.pathLabeled !== endpoint.pathLabeled
+			currentEndpoints = state[ apiName ][ version ].filter(
+				existingEndpoint => existingEndpoint.pathLabeled !== endpoint.pathLabeled
 			);
 		}
 

--- a/src/state/history/selectors.js
+++ b/src/state/history/selectors.js
@@ -1,5 +1,9 @@
-import { get } from 'lodash';
+export const getRecentEndpoints = ( state, apiName, version ) => {
+	const history = state.history[ apiName ];
 
-export const getRecentEndpoints = ( state, apiName, version ) =>
-	get( state.history, [ apiName, version ], [] )
-;
+	if ( ! history ) {
+		return [];
+	}
+
+	return history[ version ] || [];
+};

--- a/src/state/request/selectors.js
+++ b/src/state/request/selectors.js
@@ -1,4 +1,17 @@
-import { compact, isArray } from 'lodash';
+function compact( array ) {
+	let index = -1;
+	const length = array === null ? 0 : array.length;
+	let resIndex = 0;
+	const result = [];
+
+	while ( ++index < length ) {
+		const value = array[ index ];
+		if ( value ) {
+			result[ resIndex++ ] = value;
+		}
+	}
+	return result;
+}
 
 export const getSelectedEndpoint = state => state.request.endpoint;
 
@@ -31,7 +44,7 @@ export const getQueryParams = state => {
 	return queryArgs.reduce( ( ret, arg ) => {
 		if (
 			! state.request.queryParams[ arg ] || (
-				isArray( state.request.queryParams[ arg ] ) &&
+				Array.isArray( state.request.queryParams[ arg ] ) &&
 				! state.request.queryParams[ arg ].length
 			)
 		) {
@@ -79,7 +92,7 @@ export const getCompleteQueryUrl = state => {
 	const values = getPathValues( state );
 	const queryParams = getQueryParams( state );
 	const buildParamUrl = ( param, value ) => {
-		if ( isArray( value ) ) {
+		if ( Array.isArray( value ) ) {
 			return value.map( subvalue => `${ param }[]=${ encodeURIComponent( subvalue ) }` )
 				.join( '&' );
 		}

--- a/src/state/results/selectors.js
+++ b/src/state/results/selectors.js
@@ -1,4 +1,11 @@
-import { values } from 'lodash';
+export const getResults = state => {
+	const results = state.results;
 
-export const getResults = state =>
-	values( state.results ).sort( ( a, b ) => b.id - a.id );
+	if ( ! results ) {
+		return [];
+	}
+
+	return Object.keys( results )
+		.map( key => results[ key ] )
+		.sort( ( a, b ) => b.id - a.id );
+};

--- a/src/state/security/selectors.js
+++ b/src/state/security/selectors.js
@@ -1,10 +1,29 @@
-import { get } from 'lodash';
+export const isReady = ( state, apiName ) => {
+	const security = state.security[ apiName ];
 
-export const isReady = ( state, apiName ) =>
-	get( state.security, [ apiName, 'ready' ], false );
+	if ( ! security ) {
+		return false;
+	}
 
-export const isLoggedin = ( state, apiName ) =>
-	get( state.security, [ apiName, 'isLoggedin' ], false );
+	return security.ready || false;
+};
 
-export const getUser = ( state, apiName ) =>
-	get( state.security, [ apiName, 'user' ], false );
+export const isLoggedin = ( state, apiName ) => {
+	const security = state.security[ apiName ];
+
+	if ( ! security ) {
+		return false;
+	}
+
+	return security.isLoggedin || false;
+};
+
+export const getUser = ( state, apiName ) => {
+	const security = state.security[ apiName ];
+
+	if ( ! security ) {
+		return false;
+	}
+
+	return security.user || false;
+};


### PR DESCRIPTION
✅  ~**Do not merge until after #89 merges**~

Our use of the `babel-lodash-plugin` has made it hard to update our
build tool versions. It has also tied us to that plugin lest we
dramatically increase our build size.

In this patch we're replacing all uses of `lodash` functions with
alternatives, simplified copies of the `lodash` functions, or
with direct expressions equivalent to the `lodash` variants.

Build size shrinks from 164 KB gzip'd to 157 KB gzip'd.

## Testing

This needs ample testing over the changed files.

**Note**: It appears as though I'm unable to build using node16. node12 seems to work. not sure what we'll have to do to make sure this doesn't all break.