### PR TITLE
Remove unintentional optional chain introduced in #91

### DIFF
--- a/src/state/history/reducer.js
+++ b/src/state/history/reducer.js
@@ -12,9 +12,9 @@ const reducer = createReducer( {}, {
 		let currentEndpoints = [];
 
 		if ( state[ apiName ] && state[ apiName ][ version ] ) {
-			currentEndpoints = state[ apiName ][ version ]?.filter(
+			currentEndpoints = state[ apiName ][ version ].filter(
 				existingEndpoint => existingEndpoint.pathLabeled !== endpoint.pathLabeled
-			) || [];
+			);
 		}
 
 		return {


### PR DESCRIPTION
In #91 we accidentally introduced an optional chain into the source code
via accepting a change proposed during PR review through the Github interface.

It appears that the version of the project build and deployed did not include
the optional chain because it was built without pulling the updated changes
from the PR.

In this patch we're removing that and thankfully it wasn't necessary because
the optionality was already guarded against in the surrounding block.