### PR TITLE
Safeguard against empty babel plugins when building for WPCOM

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -25,6 +25,9 @@ babelLoader.include = [
 ];
 
 if ( process.env.WPCOM_BUILD ) {
+	if ( ! babelLoader.query.plugins ) {
+		babelLoader.query.plugins = [];
+	}
 	babelLoader.query.plugins.push( path.resolve(
 		__dirname, '..', 'src', 'lib', 'babel-replace-config-import.js'
 	) );


### PR DESCRIPTION
The `babel-lodash` plugin we removed in #91 was the only Babel plugin
in the project. Now that it's gone we have to recreate the plugins
array before adding our custom WPCOM plugin.