### PR TITLE
Update install instructions to use `npm ci` instead of `npm install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To setup the environment on your local system with WordPress.com APIs:
 
 1. Clone the repository `git clone https://github.com/Automattic/wp-api-console.git`.
 
-2. Install dependencies `npm install` (`npm install --legacy-peer-deps` if using node v16 or greater).
+2. Install dependencies `npm ci`.
 
 3. Open [WordPress.com Developer Resources](https://developer.wordpress.com/apps/)
 


### PR DESCRIPTION
With the introduction of a `package-lock.json` we should use `npm ci`
to "install a project with a clean slate" instead of encouraging
people to use `npm install`, which might alter the dependencies from
what's in `master`.

https://docs.npmjs.com/cli/v8/commands/npm-ci

## Testing

This only updates the README, so no testing is required other than an audit of the change to make sure my recommendation is valid.