### PR TITLE
Stop crash when param.match( paramDetailsRegex ) fails to match

### DIFF
--- a/src/api/core.js
+++ b/src/api/core.js
@@ -140,13 +140,17 @@ export const parseEndpoints = data => {
 				parameters.forEach( param => {
 					const paramDetailsRegex = /[^<]*<([^>]*)>\[?([^\])]*)/;
 					const explodedParameter = param.match( paramDetailsRegex );
-					const paramName = '$' + explodedParameter[ 1 ];
-					path[ paramName ] = {
-						description: '',
-						type: explodedParameter[ 2 ],
-					};
-					pathLabel = pathLabel.replace( param, paramName );
-					pathFormat = pathFormat.replace( param, '%s' );
+					if ( explodedParameter ) {
+						const paramName = '$' + explodedParameter[ 1 ];
+						path[ paramName ] = {
+							description: '',
+							type: explodedParameter[ 2 ],
+						};
+						pathLabel = pathLabel.replace( param, paramName );
+						pathFormat = pathFormat.replace( param, '%s' );
+					} else {
+						console.warn( 'Unable to parse param.', { param, rawpath } );
+					}
 				} );
 
 				const { group, description } = guessEndpointDocumentation( method, data.namespace, pathLabel );


### PR DESCRIPTION
## Summary

These lines can cause a fatal crash:

https://github.com/Automattic/wp-api-console/blob/014eb1c28c57cb8ca11ed9516f3c17df1a10706d/src/api/core.js#L142-L143

It has something to do with invalid data coming from the backend. It's currently happening with WP.com wpcom/v2 endpoints.
Change: Make the code more resilient and ignore the paths that do not match the regex.

## To test

* Create a wp-api-console-dev app on https://developer.wordpress.com/apps/ if you don't have one
* Set app url, redirect url, and js origins to `http://localhost:3000`
* Clone this repo and make a src/config.json file, replace client_id 12345 with yours

```
{
        "wordpress.com": {
                "client_id": "12345",
                "redirect_uri": "http://localhost:3000"
        }
}
```

* yarn && yarn start
* Open the page and choose WP REST API | wpcom/v2
* Type "a"
* Expect to see: Completion box instead of console error

![2022-08-16_10-00](https://user-images.githubusercontent.com/937354/184912550-3d72b623-ccf7-4ed0-ad93-1936521378f7.png)



