### PR TITLE
Add ability to share urls.

### DIFF
--- a/src/lib/redux/cache.js
+++ b/src/lib/redux/cache.js
@@ -18,7 +18,13 @@ function deserialize( state, reducer ) {
 	return reducer( state, { type: DESERIALIZE } );
 }
 
-export function loadInitialState( initialState, reducer ) {
+export function loadInitialState( initialState, initialStateFromUrl, reducer ) {
+
+	// URL state overrides local storage state
+	if ( initialStateFromUrl ) {
+		return reducer( initialStateFromUrl, { type: DESERIALIZE } );
+	}
+
 	const localStorageState = JSON.parse( localStorage.getItem( STORAGE_KEY ) ) || {};
 	if ( localStorageState._timestamp && localStorageState._timestamp + MAX_AGE < Date.now() ) {
 		return initialState;

--- a/src/state/index.js
+++ b/src/state/index.js
@@ -1,14 +1,14 @@
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
-
+import router, { getStateFromUrl } from './router';
 import reducer from './reducer';
 import { boot } from './security/actions';
 import { loadInitialState, persistState } from '../lib/redux/cache';
 
 const store = createStore(
 	reducer,
-	loadInitialState( {}, reducer ),
-	applyMiddleware( thunk )
+	loadInitialState( {}, getStateFromUrl(), reducer ),
+	applyMiddleware( thunk, router )
 );
 persistState( store, reducer );
 store.dispatch( boot() );

--- a/src/state/request/reducer.js
+++ b/src/state/request/reducer.js
@@ -11,7 +11,7 @@ import {
 } from '../actions';
 import schema from './schema';
 
-const defaultState = {
+export const defaultState = {
 	method: 'GET',
 	endpoint: false,
 	pathValues: {},

--- a/src/state/router.js
+++ b/src/state/router.js
@@ -1,0 +1,143 @@
+
+import { REQUEST_TRIGGER, API_VERSIONS_RECEIVE, REQUEST_SELECT_ENDPOINT } from './actions';
+import { defaultState as defaultRequestState } from './request/reducer';
+import { defaultState as defaultUiState } from './ui/reducer';
+import { loadEndpoints } from './endpoints/actions';
+import { getEndpoints } from './endpoints/selectors';
+
+function getUrlParams() {
+	return new URL( window.location.href ).searchParams;
+}
+
+function encodeString( val ) {
+	return ( val === null || val === undefined ) ? '' : encodeURIComponent( val );
+}
+
+function encodeObject( val ) {
+	return ( typeof val === 'object' ) && Object.keys( val ).length === 0 ? '' : encodeURIComponent( JSON.stringify( val ) );
+}
+
+function decodeString( val ) {
+	return decodeURIComponent( val );
+}
+
+function decodeObject( val ) {
+	return JSON.parse( decodeURIComponent( val ) );
+}
+
+export const getUrlFromState = state => {
+
+	const { request, ui } = state;
+
+	const params = {
+		bodyParams: encodeObject( request.bodyParams ),
+		endpoint: encodeString( request.endpoint ? request.endpoint.pathLabeled : '' ),
+		method: encodeString( request.method ),
+		pathValues: encodeObject( request.pathValues ),
+		queryParams: encodeObject( request.queryParams ),
+		url: encodeString( request.url ),
+		api: encodeString( ui.api ),
+		version: encodeString( ui.version ),
+	};
+
+	// Discard empty params
+	Object.keys( params ).forEach( key => ! params[ key ] && ( delete params[ key ] ) );
+
+	// Construct url
+	const urlParams = new URLSearchParams( params );
+	const url = window.location.origin + window.location.pathname + '?' + urlParams.toString();
+
+	return url;
+};
+
+export const getStateFromUrl = () => {
+	const urlParams = getUrlParams();
+
+	if ( urlParams.toString() === '' ) {
+		return false;
+	}
+
+	const state = { request: { ...defaultRequestState }, ui: { ...defaultUiState } };
+
+	try {
+		for ( const [ key, value ] of urlParams.entries() ) {
+			switch ( key ) {
+				case 'bodyParams':
+					state.request.bodyParams = decodeObject( value );
+					break;
+				case 'method':
+					state.request.method = decodeString( value );
+					break;
+				case 'pathValues':
+					state.request.pathValues = decodeObject( value );
+					break;
+				case 'queryParams':
+					state.request.queryParams = decodeObject( value );
+					break;
+				case 'url':
+					state.request.url = decodeString( value );
+					break;
+				case 'api':
+					state.ui.api = decodeString( value );
+					break;
+				case 'version':
+					state.ui.version = decodeString( value );
+					break;
+				default:
+					break;
+			}
+		}
+	} catch ( e ) {
+		// Fail without breaking the app
+		console.error( 'Could not parse state from url params.', e );
+		return false;
+	}
+
+	return state;
+};
+
+const router = ( { getState, dispatch } ) => {
+
+	// Determine if we need to load and select the endpoint
+	let isInitializingEndpoint = false;
+
+	const { ui = {} } = getStateFromUrl();
+	const endpointUrlParam = getUrlParams().get( 'endpoint' );
+	const endpointPathLabeled = endpointUrlParam ? decodeURIComponent( endpointUrlParam ) : false;
+	const apiName = ui.api;
+	const apiVersion = ui.version;
+
+	if ( endpointPathLabeled && apiName && apiVersion ) {
+		loadEndpoints( apiName, apiVersion )( dispatch );
+		isInitializingEndpoint = true;
+	}
+
+	return next => action => {
+		const state = getState();
+
+		switch ( action.type ) {
+			case REQUEST_TRIGGER:
+				const url = getUrlFromState( state );
+				console.log( state );
+				window.history.pushState( {}, document.title, url );
+				break;
+			case API_VERSIONS_RECEIVE:
+				// Once the endpoint is loaded, select the endpoint.
+				if ( isInitializingEndpoint ) {
+					const endpoints = getEndpoints( state, apiName, apiVersion );
+					const endpoint = endpoints.find( ( { pathLabeled } ) => pathLabeled === endpointPathLabeled );
+					if ( endpoint ) {
+						dispatch( { type: REQUEST_SELECT_ENDPOINT, payload: { endpoint } } );
+					}
+					isInitializingEndpoint = false;
+				}
+				break;
+			default:
+				break;
+		}
+
+		return next( action );
+	};
+};
+
+export default router;

--- a/src/state/ui/reducer.js
+++ b/src/state/ui/reducer.js
@@ -3,7 +3,12 @@ import { UI_SELECT_API, UI_SELECT_VERSION } from '../actions';
 import { getDefault } from '../../api';
 import schema from './schema';
 
-const reducer = createReducer( { api: getDefault().name, version: null }, {
+export const defaultState = {
+	api: getDefault().name,
+	version: null,
+};
+
+const reducer = createReducer( defaultState, {
 	[ UI_SELECT_API ]: ( state, { payload } ) => {
 		return ( {
 			version: null,


### PR DESCRIPTION
This PR generates a shareable URL and pushes the browser history state, allowing the URL to be copied from the address bar and shared to colleagues.

In order to achieve this, I created a redux middleware called `router` is would encode and decode relevant states to and from urls.

You can test this with the following urls and you can see the values prefilled:
 - Manual URL: http://localhost:3000/?method=GET&url=%252Fsites%252F201582167%252Fsubscribers&api=WP%2520REST%2520API&version=wpcom%252Fv2
 - Selected From Endpoint Suggestion: http://localhost:3000/?endpoint=%252Fsites%252F%2524site%252Fcomments%252F%2524comment_ID&method=GET&pathValues=%257B%2522%2524site%2522%253A%2522201582167%2522%257D&queryParams=%257B%2522http_envelope%2522%253A%25220%2522%252C%2522fields%2522%253A%2522ID%252Cpost%252CURL%252Cshort_URL%252Ccontent%2522%252C%2522meta%2522%253A%2522post%252Clikes%2522%252C%2522pretty%2522%253A%2522false%2522%257D&api=WP.COM%2520API&version=v1.1