### PR TITLE
Fixed bug in `localStorage`'s state persistence logic

### DIFF
--- a/src/lib/redux/cache.js
+++ b/src/lib/redux/cache.js
@@ -33,7 +33,7 @@ export function persistState( store, reducer ) {
 
 	store.subscribe( () => {
 		const nextState = store.getState();
-		needsStoring = nextState === state;
+		needsStoring = nextState !== state;
 		state = nextState;
 	} );
 


### PR DESCRIPTION
This PR fixes a problem where the state is never saved to `localStorage`.

Now, every time the state _changes_, the state is marked to be persisted.

This has the immediate advantage of persisting the API, version, and URL in the header between sessions.

Before:
![image](https://github.com/Automattic/wp-api-console/assets/3801502/8252ce14-b7e8-4da6-b06b-aea592079f74)

After:
![image](https://github.com/Automattic/wp-api-console/assets/3801502/a379aa21-47b8-4671-8994-7b920c4f1170)
