### PR TITLE
[Draft] Added results persistence

### DIFF
--- a/src/state/results/reducer.js
+++ b/src/state/results/reducer.js
@@ -1,5 +1,6 @@
 import { createReducer } from '../../lib/redux/create-reducer';
 import { REQUEST_RESULTS_RECEIVE, REQUEST_TRIGGER } from '../actions';
+import schema from './schema';
 
 const reducer = createReducer( {}, {
 	[ REQUEST_TRIGGER ]: ( state, { payload: { id, version, apiName, method, path } } ) => {
@@ -19,6 +20,6 @@ const reducer = createReducer( {}, {
 			},
 		};
 	},
-} );
+}, schema );
 
 export default reducer;

--- a/src/state/results/schema.js
+++ b/src/state/results/schema.js
@@ -1,0 +1,5 @@
+const schema = {
+	type: 'object',
+};
+
+export default schema;


### PR DESCRIPTION
PoC - do not merge!

This PR adds the request history to the `localStorage`, so we don't lose our previous requests after a refresh or on a new browser session on a different day.

It's built on top of https://github.com/Automattic/wp-api-console/pull/108