### PR TITLE
Add Share Button and URL State Setup

### DIFF
--- a/src/components/header/index.jsx
+++ b/src/components/header/index.jsx
@@ -6,6 +6,7 @@ import ApiSelector from '../api-selector';
 import UserMenu from '../user-menu';
 import VersionSelector from '../version-selector';
 import LookupContainer from '../lookup-container';
+import Share from '../share';
 import Submit from '../submit';
 
 const Header = () =>
@@ -14,6 +15,7 @@ const Header = () =>
 			<ApiSelector />
 			<VersionSelector />
 			<LookupContainer />
+			<Share />
 			<Submit />
 			<UserMenu />
 		</div>

--- a/src/components/share/index.jsx
+++ b/src/components/share/index.jsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import { connect } from 'react-redux';
+
+import './style.css';
+
+const Share = ( { api, version, method, url } ) => {
+	const [ buttonText, setButtonText ] = useState( 'Share' );
+
+	const buildShareableLink = () => {
+		const baseUrl = window.location.href.split( '?' )[ 0 ];
+		const queryParams = new URLSearchParams( { api, version, method, url } ).toString();
+		const shareableUrl = `${ baseUrl }?${ queryParams }`;
+
+		navigator.clipboard
+			.writeText( shareableUrl )
+			.then( () => {
+				setButtonText( 'Copied!' );
+				setTimeout( () => setButtonText( 'Share' ), 2000 );
+			} )
+			.catch( ( err ) => console.error( 'Error copying URL to clipboard', err ) ); // Error handling
+	};
+
+	return (
+		<button id="share-button" onClick={ buildShareableLink }>
+			{ buttonText }
+		</button>
+	);
+};
+
+const mapStateToProps = ( state ) => ( {
+	api: state.ui.api,
+	version: state.ui.version,
+	method: state.request.method,
+	url: state.request.url,
+} );
+
+export default connect( mapStateToProps )( Share );

--- a/src/components/share/index.jsx
+++ b/src/components/share/index.jsx
@@ -3,12 +3,29 @@ import { connect } from 'react-redux';
 
 import './style.css';
 
-const Share = ( { api, version, method, url } ) => {
+const Share = ( { api, version, method, url, pathLabeled, pathValues, queryParams } ) => {
 	const [ buttonText, setButtonText ] = useState( 'Share' );
 
+	// The API console has two methods, 1. Directly type in the URL, 2. Use the form to build the URL.
+	// I'm calling 2 the "madlibs" method, because it's like filling in the blanks of a story.
+	// This function constructs the madlibs path if we can't use the direct request.url.
+	const constructMadlibsPath = () => {
+		let path = pathLabeled;
+		Object.keys( pathValues ).forEach( ( key ) => {
+			path = path.replace( key, encodeURIComponent( pathValues[ key ] ) );
+			console.log( key, pathValues[ key ], path );
+		} );
+		if ( queryParams ) {
+			const queryParamsString = new URLSearchParams( queryParams ).toString();
+			path += `?${ queryParamsString }`;
+		}
+		return path;
+	};
+
 	const buildShareableLink = () => {
-		const baseUrl = window.location.href.split( '?' )[ 0 ];
-		const queryParams = new URLSearchParams( { api, version, method, url } ).toString();
+		const finalPath = url || constructMadlibsPath();
+		const baseUrl = window.location.origin;
+		const queryParams = new URLSearchParams( { api, version, method, url: finalPath } ).toString();
 		const shareableUrl = `${ baseUrl }?${ queryParams }`;
 
 		navigator.clipboard
@@ -32,6 +49,9 @@ const mapStateToProps = ( state ) => ( {
 	version: state.ui.version,
 	method: state.request.method,
 	url: state.request.url,
+	pathValues: state.request?.pathValues,
+	queryParams: state.request?.queryParams,
+	pathLabeled: state.request?.endpoint?.pathLabeled,
 } );
 
 export default connect( mapStateToProps )( Share );

--- a/src/components/share/style.css
+++ b/src/components/share/style.css
@@ -1,0 +1,16 @@
+#share-button {
+	cursor: pointer;
+	min-width: 44px;
+	background-color: #fff;
+	border: 0;
+	color: rgb(133, 192, 224);
+	transition: background-color 0.2s ease, color 0.2s ease;
+}
+#share-button:hover, #share-button:focus {
+	background-color: rgb(133, 192, 224);
+	color: #fff;
+}
+#share-button:active {
+	background-color: rgb(103, 162, 194);
+	color: #fff;
+}

--- a/src/state/index.js
+++ b/src/state/index.js
@@ -4,6 +4,7 @@ import thunk from 'redux-thunk';
 import reducer from './reducer';
 import { boot } from './security/actions';
 import { loadInitialState, persistState } from '../lib/redux/cache';
+import initStateFromUrl from './init-state-from-url';
 
 const store = createStore(
 	reducer,
@@ -12,5 +13,6 @@ const store = createStore(
 );
 persistState( store, reducer );
 store.dispatch( boot() );
+initStateFromUrl( store );
 
 export default store;

--- a/src/state/init-state-from-url.js
+++ b/src/state/init-state-from-url.js
@@ -1,0 +1,23 @@
+import { selectApi, selectVersion } from './ui/actions';
+import { updateMethod, updateUrl } from './request/actions';
+
+function initStateFromUrl( store ) {
+	const requestUrl = new URL( window.location );
+	const api = requestUrl.searchParams.get( 'api' );
+	const version = requestUrl.searchParams.get( 'version' );
+	const method = requestUrl.searchParams.get( 'method' );
+	const url = requestUrl.searchParams.get( 'url' );
+	if ( api ) {
+		store.dispatch( selectApi( api ) );
+	}
+	if ( version ) {
+		store.dispatch( selectVersion( version ) );
+	}
+	if ( method ) {
+		store.dispatch( updateMethod( method ) );
+	}
+	if ( url ) {
+		store.dispatch( updateUrl( url ) );
+	}
+}
+export default initStateFromUrl;


### PR DESCRIPTION
### Added:

* **Share Button**: There's now a share button in the header. Hit it to copy a link that keeps your current request setup. It should make it easier when we need to sent over an API state to someone else or to put it in testing instruction.
* **URL State Loading**: The app now picks up API, version, method, and URL params from the URL and sets up shop right when you open it. So if you've got a link with all the info, the app will load up with those settings straight away.

### Screenshot

![2023-11-13_11-02](https://github.com/Automattic/wp-api-console/assets/937354/66317ff0-a3e8-4944-aa83-5df5da140d76)

```
http://localhost:3000?api=WP.COM+API&version=v1.2&method=GET&url=%2Fme%2Fsites
```

### Possible issues

* No icon
* Browser url and actual api request can get out of sync
* "Sharing" a "madlibs-style" request works, but upon load it's converted to "directly type" style. Not sure if I got everything here.
* I think I have to keep logging in because the URL is changing?
